### PR TITLE
Fix analyzer warnings: UNUSED_CATCH_CLAUSE

### DIFF
--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -210,7 +210,7 @@ class HtmlParser {
       try {
         mainLoop();
         break;
-      } on ReparseException catch (e) {
+      } on ReparseException {
         // Note: this happens if we start parsing but the character encoding
         // changes. So we should only need to restart very early in the parse.
         reset();

--- a/lib/src/encoding_parser.dart
+++ b/lib/src/encoding_parser.dart
@@ -154,7 +154,7 @@ class EncodingParser {
         }
         data.position += 1;
       }
-    } on StateError catch (e) {
+    } on StateError {
       // Catch this here to match behavior of Python's StopIteration
       // TODO(jmesserly): refactor to not use exceptions
     }
@@ -352,12 +352,12 @@ class ContentAttrParser {
         try {
           data.skipUntil(isWhitespace);
           return data.slice(oldPosition, data.position);
-        } on StateError catch (e) {
+        } on StateError {
           //Return the whole remaining value
           return data.slice(oldPosition);
         }
       }
-    } on StateError catch (e) {
+    } on StateError {
       return null;
     }
   }


### PR DESCRIPTION
Fixes warnings like:

157: The exception variable 'e' is not used, so the 'catch' clause can be removed [UNUSED_CATCH_CLAUSE]
355: The exception variable 'e' is not used, so the 'catch' clause can be removed [UNUSED_CATCH_CLAUSE]
360: The exception variable 'e' is not used, so the 'catch' clause can be removed [UNUSED_CATCH_CLAUSE]
