### PR TITLE
Changed tagName tokenizer such that finding EOF within tagName will r…

### DIFF
--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -570,7 +570,8 @@ class HtmlTokenizer implements Iterator<Token> {
     } else if (data == ">") {
       emitCurrentToken();
     } else if (data == EOF) {
-      _addToken(new ParseErrorToken("eof-in-tag-name"));
+      _addToken(new CharactersToken("<" + currentTagToken.name));
+      stream.unget(data);
       state = dataState;
     } else if (data == "/") {
       state = selfClosingStartTagState;

--- a/test/data/tokenizer/test4.test
+++ b/test/data/tokenizer/test4.test
@@ -303,11 +303,11 @@
 
 {"description":"EOF in tag name state ",
 "input":"<a",
-"output":["ParseError"]},
+"output":[["Character","<a"]]},
 
 {"description":"EOF in tag name state",
 "input":"<a",
-"output":["ParseError"]},
+"output":[["Character","<a"]]},
 
 {"description":"EOF in before attribute name state",
 "input":"<a ",

--- a/test/data/tree-construction/webkit01.dat
+++ b/test/data/tree-construction/webkit01.dat
@@ -34,6 +34,7 @@ Line: 1 Col: 4 Unexpected non-space characters. Expected DOCTYPE.
 | <html>
 |   <head>
 |   <body>
+|     "<di"
 
 #data
 <div>Hello</div>


### PR DESCRIPTION
Requested change to add Text node on unclosed tag names found at the very end of the document. 
This is needed for https://github.com/dart-lang/angular_analyzer_plugin for autocompletion of HTML tags with user-defined selectors and exportAs. 

