### PR TITLE
fix an issue when run with --preview-dart-2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Don’t commit the following directories created by pub.
 .pub
+.dart_tool/
 build/
 packages
 .packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
+## 0.13.3
+
+ * Update the signatures of `FilteredElementList.indexOf` and
+   `FilteredElementList.lastIndexOf` to include type annotations.
+
 ## 0.13.2+2
 
-* Update signature for implementations of `Iterable.singleWhere` to include 
-  optional argument.
+ * Update signature for implementations of `Iterable.singleWhere` to include
+   optional argument.
 
 ## 0.13.2+1
 
-* Changed the implementation of `Set` and `List` classes to use base classes
-  from `dart:collection`.
+ * Changed the implementation of `Set` and `List` classes to use base classes
+   from `dart:collection`.
 
 ## 0.13.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Update signature for implementations of `Iterable.singleWhere` to include 
   optional argument.
-   
+
 ## 0.13.2+1
 
 * Changed the implementation of `Set` and `List` classes to use base classes

--- a/lib/dom.dart
+++ b/lib/dom.dart
@@ -969,11 +969,11 @@ class FilteredElementList extends IterableBase<Element>
       _filtered.getRange(start, end);
   // TODO(sigmund): this should be typed Element, but we currently run into a
   // bug where ListMixin<E>.indexOf() expects Object as the argument.
-  int indexOf(element, [int start = 0]) => _filtered.indexOf(element, start);
+  int indexOf(Object element, [int start = 0]) => _filtered.indexOf(element, start);
 
   // TODO(sigmund): this should be typed Element, but we currently run into a
   // bug where ListMixin<E>.lastIndexOf() expects Object as the argument.
-  int lastIndexOf(element, [int start]) {
+  int lastIndexOf(Object element, [int start]) {
     if (start == null) start = length - 1;
     return _filtered.lastIndexOf(element, start);
   }

--- a/lib/dom.dart
+++ b/lib/dom.dart
@@ -969,7 +969,8 @@ class FilteredElementList extends IterableBase<Element>
       _filtered.getRange(start, end);
   // TODO(sigmund): this should be typed Element, but we currently run into a
   // bug where ListMixin<E>.indexOf() expects Object as the argument.
-  int indexOf(Object element, [int start = 0]) => _filtered.indexOf(element, start);
+  int indexOf(Object element, [int start = 0]) =>
+      _filtered.indexOf(element, start);
 
   // TODO(sigmund): this should be typed Element, but we currently run into a
   // bug where ListMixin<E>.lastIndexOf() expects Object as the argument.


### PR DESCRIPTION
This package can't run with the --preview-dart-2 flag currently (and is a transitive dependency of other tools like the analyzer, which also can't run in preview dart 2 as a result). Here's the failure:

```
lib/dom.dart:972:15: Error: Can't infer the type of 'element': overridden members must all have the same type.
Specify the type explicitly.
  int indexOf(element, [int start = 0]) => _filtered.indexOf(element, start);
              ^
lib/dom.dart:976:19: Error: Can't infer the type of 'element': overridden members must all have the same type.
Specify the type explicitly.
  int lastIndexOf(element, [int start]) {
                  ^
```

