### PR TITLE
Refactor some utilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,17 @@ dart:
 dart_task:
   - test: -p vm
   - test: -p chrome
-  - dartanalyzer: --fatal-warnings --fatal-infos .
 
 matrix:
   include:
     - dart: dev
       dart_task: dartfmt
+    - dart: dev
+      dart_task:
+        dartanalyzer: --fatal-warnings --fatal-infos .
+    - dart: 2.3.0
+      dart_task:
+        dartanalyzer: --fatal-warnings .
 
 # Only building master means that we don't run two builds for each pull request.
 branches:

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,5 +1,3 @@
-library constants;
-
 import 'utils.dart';
 
 // TODO(jmesserly): fix up the const lists. For the bigger ones, we need faster
@@ -513,44 +511,6 @@ const rcdataElements = [
   'noframes',
   'noscript'
 ];
-
-const Map<String, List<String>> booleanAttributes = {
-  '': [
-    'irrelevant',
-  ],
-  'style': [
-    'scoped',
-  ],
-  'img': [
-    'ismap',
-  ],
-  'audio': ['autoplay', 'controls'],
-  'video': ['autoplay', 'controls'],
-  'script': ['defer', 'async'],
-  'details': [
-    'open',
-  ],
-  'datagrid': ['multiple', 'disabled'],
-  'command': ['hidden', 'disabled', 'checked', 'default'],
-  'hr': ['noshade'],
-  'men': [
-    'autosubmit',
-  ],
-  'fieldset': ['disabled', 'readonly'],
-  'option': ['disabled', 'readonly', 'selected'],
-  'optgroup': ['disabled', 'readonly'],
-  'button': ['disabled', 'autofocus'],
-  'input': [
-    'disabled',
-    'readonly',
-    'required',
-    'autofocus',
-    'checked',
-    'ismap'
-  ],
-  'select': ['disabled', 'readonly', 'autofocus', 'multiple'],
-  'output': ['disabled', 'readonly'],
-};
 
 // entitiesWindows1252 has to be _ordered_ and needs to have an index. It
 // therefore can't be a frozenset.

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -187,7 +187,7 @@ class HtmlTokenizer implements Iterator<Token> {
     }
 
     // Convert the set of characters consumed to an int.
-    var charAsInt = parseIntRadix(charStack.join(), radix);
+    var charAsInt = int.parse(charStack.join(), radix: radix);
 
     // Certain characters get replaced with others
     var char = replacementCharacters[charAsInt];

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,9 +1,4 @@
-/// Misc things that were useful when porting the code from Python.
-library utils;
-
 import 'constants.dart';
-
-typedef Predicate = bool Function();
 
 class Pair<F, S> {
   final F first;
@@ -18,32 +13,8 @@ class Pair<F, S> {
   bool operator ==(other) => other.first == first && other.second == second;
 }
 
-int parseIntRadix(String str, [int radix = 10]) {
-  var val = 0;
-  for (var i = 0; i < str.length; i++) {
-    var digit = str.codeUnitAt(i);
-    if (digit >= LOWER_A) {
-      digit += 10 - LOWER_A;
-    } else if (digit >= UPPER_A) {
-      digit += 10 - UPPER_A;
-    } else {
-      digit -= ZERO;
-    }
-    val = val * radix + digit;
-  }
-  return val;
-}
-
-bool any(List<bool> iterable) => iterable.any((f) => f);
-
-bool startsWithAny(String str, List<String> prefixes) {
-  for (var prefix in prefixes) {
-    if (str.startsWith(prefix)) {
-      return true;
-    }
-  }
-  return false;
-}
+bool startsWithAny(String str, List<String> prefixes) =>
+    prefixes.any(str.startsWith);
 
 // Like the python [:] operator.
 List<T> slice<T>(List<T> list, int start, [int end]) {
@@ -85,8 +56,6 @@ String formatStr(String format, Map data) {
     var result = StringBuffer();
     var search = '%($key)';
     int last = 0, match;
-    // This is a bug in the linter
-    // ignore: prefer_contains
     while ((match = format.indexOf(search, last)) >= 0) {
       result.write(format.substring(last, match));
       match += search.length;


### PR DESCRIPTION
- Drop the `Predicate` typedef, it is unused.
- Remove `parseIntRadix`, replace with `int.parse`.
- Remove unnecessary `library` directives and a comment that added no
  information.
- Drop unused constants.
- Simplify `startsWithAny`.
- Remove an ignore that was working around an analyzer bug which no
  longer exists.