### PR TITLE
Fix infinite loop with bad button close tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.14.0+4
+
+- Fix a bug parsing bad HTML where a 'button' end tag needs to close other
+  elements.
+
 ## 0.14.0+3
 
 - Fix spans generated for HTML with higher-plane unicode characters

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -1411,8 +1411,8 @@ class InBodyPhase extends Phase {
       case 'address':
       case 'article':
       case 'aside':
-      case 'button':
       case 'blockquote':
+      case 'button':
       case 'center':
       case 'details':
       case 'dir':

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -1411,6 +1411,7 @@ class InBodyPhase extends Phase {
       case 'address':
       case 'article':
       case 'aside':
+      case 'button':
       case 'blockquote':
       case 'center':
       case 'details':

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: html
-version: 0.14.0+3
+version: 0.14.0+4
 
 description: APIs for parsing and manipulating HTML content outside the browser.
 author: Dart Team <misc@dartlang.org>

--- a/test/data/tree-construction/regression_tests.dat
+++ b/test/data/tree-construction/regression_tests.dat
@@ -1,0 +1,13 @@
+#data
+<button><p></button><button></button>
+#info
+Regression test for https://github.com/dart-lang/html/issues/122
+#errors
+Errors are currently untested: https://github.com/dart-lang/html/issues/127
+#document
+| <html>
+|   <head>
+|   <body>
+|     <button>
+|       <p>
+|     <button>


### PR DESCRIPTION
Closes #122

Add 'button' to the tags that are processed with `endTagBlock`. The spec
at https://html.spec.whatwg.org/multipage/parsing.html includes 'button'
in the list of end tags with this treatment.

Add a new `.dat` file for regression test. It include an `#info` field
which is new but can be parsed safely to mark the issue for which it is
a test. This test loops endlessly before the fix and passes after the
fix.

Note that since errors are currently untested and tests fail if they are
tested the error will be left without content for now.