### PR TITLE
Disable implicit casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.15.0-dev
+
 ## 0.14.0+4
 
 - Fix a bug parsing bad HTML where a 'button' end tag needs to close other

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,7 @@
 include: package:pedantic/analysis_options.yaml
 analyzer:
+  strong-mode:
+    implicit-casts: false
   errors:
     # https://github.com/dart-lang/linter/issues/1649
     prefer_collection_literals: ignore

--- a/lib/dom.dart
+++ b/lib/dom.dart
@@ -1058,17 +1058,15 @@ class FilteredElementList extends IterableBase<Element>
   @override
   Iterable<Element> getRange(int start, int end) =>
       _filtered.getRange(start, end);
-  // TODO(sigmund): this should be typed Element, but we currently run into a
-  // bug where ListMixin<E>.indexOf() expects Object as the argument.
   @override
   int indexOf(Object element, [int start = 0]) =>
+      // Cast force by ListMixin https://github.com/dart-lang/sdk/issues/31311
       _filtered.indexOf(element as Element, start);
 
-  // TODO(sigmund): this should be typed Element, but we currently run into a
-  // bug where ListMixin<E>.lastIndexOf() expects Object as the argument.
   @override
   int lastIndexOf(Object element, [int start]) {
     start ??= length - 1;
+    // Cast force by ListMixin https://github.com/dart-lang/sdk/issues/31311
     return _filtered.lastIndexOf(element as Element, start);
   }
 

--- a/lib/dom.dart
+++ b/lib/dom.dart
@@ -1060,13 +1060,13 @@ class FilteredElementList extends IterableBase<Element>
       _filtered.getRange(start, end);
   @override
   int indexOf(Object element, [int start = 0]) =>
-      // Cast force by ListMixin https://github.com/dart-lang/sdk/issues/31311
+      // Cast forced by ListMixin https://github.com/dart-lang/sdk/issues/31311
       _filtered.indexOf(element as Element, start);
 
   @override
   int lastIndexOf(Object element, [int start]) {
     start ??= length - 1;
-    // Cast force by ListMixin https://github.com/dart-lang/sdk/issues/31311
+    // Cast forced by ListMixin https://github.com/dart-lang/sdk/issues/31311
     return _filtered.lastIndexOf(element as Element, start);
   }
 

--- a/lib/dom.dart
+++ b/lib/dom.dart
@@ -24,7 +24,7 @@ export 'src/css_class_set.dart' show CssClassSet;
 
 // TODO(jmesserly): this needs to be replaced by an AttributeMap for attributes
 // that exposes namespace info.
-class AttributeName implements Comparable {
+class AttributeName implements Comparable<Object> {
   /// The namespace prefix, e.g. `xlink`.
   final String prefix;
 
@@ -55,14 +55,15 @@ class AttributeName implements Comparable {
   }
 
   @override
-  int compareTo(other) {
+  int compareTo(dynamic other) {
     // Not sure about this sort order
     if (other is! AttributeName) return 1;
-    var cmp = (prefix ?? '').compareTo((other.prefix ?? ''));
+    final otherAttributeName = other as AttributeName;
+    var cmp = (prefix ?? '').compareTo((otherAttributeName.prefix ?? ''));
     if (cmp != 0) return cmp;
-    cmp = name.compareTo(other.name);
+    cmp = name.compareTo(otherAttributeName.name);
     if (cmp != 0) return cmp;
-    return namespace.compareTo(other.namespace);
+    return namespace.compareTo(otherAttributeName.namespace);
   }
 
   @override
@@ -141,7 +142,10 @@ abstract class Node {
   ///
   /// Returns null if this node either does not have a parent or its parent is
   /// not an element.
-  Element get parent => parentNode is Element ? parentNode : null;
+  Element get parent {
+    final parentNode = this.parentNode;
+    return parentNode is Element ? parentNode : null;
+  }
 
   // TODO(jmesserly): should move to Element.
   /// A map holding name, value pairs for attributes of the node.
@@ -299,7 +303,7 @@ abstract class Node {
     }
   }
 
-  Node _clone(Node shallowClone, bool deep) {
+  T _clone<T extends Node>(T shallowClone, bool deep) {
     if (deep) {
       for (var child in nodes) {
         shallowClone.append(child.clone(true));
@@ -442,7 +446,7 @@ class Text extends Node {
 
   void appendData(String data) {
     if (_data is! StringBuffer) _data = StringBuffer(_data);
-    StringBuffer sb = _data;
+    final sb = _data as StringBuffer;
     sb.write(data);
   }
 
@@ -1058,14 +1062,14 @@ class FilteredElementList extends IterableBase<Element>
   // bug where ListMixin<E>.indexOf() expects Object as the argument.
   @override
   int indexOf(Object element, [int start = 0]) =>
-      _filtered.indexOf(element, start);
+      _filtered.indexOf(element as Element, start);
 
   // TODO(sigmund): this should be typed Element, but we currently run into a
   // bug where ListMixin<E>.lastIndexOf() expects Object as the argument.
   @override
   int lastIndexOf(Object element, [int start]) {
     start ??= length - 1;
-    return _filtered.lastIndexOf(element, start);
+    return _filtered.lastIndexOf(element as Element, start);
   }
 
   @override

--- a/lib/dom_parsing.dart
+++ b/lib/dom_parsing.dart
@@ -10,17 +10,17 @@ class TreeVisitor {
   void visit(Node node) {
     switch (node.nodeType) {
       case Node.ELEMENT_NODE:
-        return visitElement(node);
+        return visitElement(node as Element);
       case Node.TEXT_NODE:
-        return visitText(node);
+        return visitText(node as Text);
       case Node.COMMENT_NODE:
-        return visitComment(node);
+        return visitComment(node as Comment);
       case Node.DOCUMENT_FRAGMENT_NODE:
-        return visitDocumentFragment(node);
+        return visitDocumentFragment(node as DocumentFragment);
       case Node.DOCUMENT_NODE:
-        return visitDocument(node);
+        return visitDocument(node as Document);
       case Node.DOCUMENT_TYPE_NODE:
-        return visitDocumentType(node);
+        return visitDocumentType(node as DocumentType);
       default:
         throw UnsupportedError('DOM node type ${node.nodeType}');
     }

--- a/lib/src/token.dart
+++ b/lib/src/token.dart
@@ -63,9 +63,7 @@ abstract class StringToken extends Token {
     return _string;
   }
 
-  StringToken(string)
-      : _string = string,
-        _buffer = string == null ? StringBuffer() : null;
+  StringToken(this._string) : _buffer = _string == null ? StringBuffer() : null;
 
   StringToken add(String data) {
     _buffer.write(data);

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -51,9 +51,7 @@ class HtmlTokenizer implements Iterator<Token> {
   Token currentToken;
 
   /// Holds a reference to the method to be invoked for the next parser state.
-  // TODO(jmesserly): the type should be "Predicate" but a dart2js checked mode
-  // bug prevents us from doing that. See http://dartbug.com/12465
-  Function state;
+  bool Function() state;
 
   final StringBuffer _buffer = StringBuffer();
 
@@ -79,9 +77,9 @@ class HtmlTokenizer implements Iterator<Token> {
     reset();
   }
 
-  TagToken get currentTagToken => currentToken;
-  DoctypeToken get currentDoctypeToken => currentToken;
-  StringToken get currentStringToken => currentToken;
+  TagToken get currentTagToken => currentToken as TagToken;
+  DoctypeToken get currentDoctypeToken => currentToken as DoctypeToken;
+  StringToken get currentStringToken => currentToken as StringToken;
 
   Token _current;
   @override

--- a/lib/src/treebuilder.dart
+++ b/lib/src/treebuilder.dart
@@ -13,7 +13,7 @@ import 'utils.dart';
 // The scope markers are inserted when entering object elements,
 // marquees, table cells, and table captions, and are used to prevent formatting
 // from "leaking" into tables, object elements, and marquees.
-const Node Marker = null;
+const Element Marker = null;
 
 // TODO(jmesserly): this should extend ListBase<Element>, but my simple attempt
 // didn't work.
@@ -230,7 +230,7 @@ class TreeBuilder {
     return null;
   }
 
-  void insertRoot(Token token) {
+  void insertRoot(StartTagToken token) {
     var element = createElement(token);
     openElements.add(element);
     document.nodes.add(element);
@@ -273,7 +273,7 @@ class TreeBuilder {
     return element;
   }
 
-  Element insertElementTable(token) {
+  Element insertElementTable(StartTagToken token) {
     /// Create an element and insert it into the tree
     var element = createElement(token);
     if (!tableInsertModeElements.contains(openElements.last.localName)) {
@@ -307,7 +307,7 @@ class TreeBuilder {
       // We should be in the InTable mode. This means we want to do
       // special magic element rearranging
       var nodePos = getTableMisnestedNodePosition();
-      _insertText(nodePos[0], data, span, nodePos[1]);
+      _insertText(nodePos[0], data, span, nodePos[1] as Element);
     }
   }
 
@@ -318,7 +318,7 @@ class TreeBuilder {
     var nodes = parent.nodes;
     if (refNode == null) {
       if (nodes.isNotEmpty && nodes.last is Text) {
-        Text last = nodes.last;
+        final last = nodes.last as Text;
         last.appendData(data);
 
         if (span != null) {
@@ -331,7 +331,7 @@ class TreeBuilder {
     } else {
       var index = nodes.indexOf(refNode);
       if (index > 0 && nodes[index - 1] is Text) {
-        Text last = nodes[index - 1];
+        final last = nodes[index - 1] as Text;
         last.appendData(data);
       } else {
         nodes.insert(index, Text(data)..sourceSpan = span);
@@ -345,7 +345,7 @@ class TreeBuilder {
     // The foster parent element is the one which comes before the most
     // recently opened table element
     // XXX - this is really inelegant
-    Node lastTable;
+    Element lastTable;
     Node fosterParent;
     Node insertBefore;
     for (var elm in openElements.reversed) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -79,7 +79,7 @@ String formatStr(String format, Map data) {
           result.write(padWithZeros(number, numberSize));
           break;
         case 'x':
-          var number = value.toRadixString(16);
+          var number = (value as int).toRadixString(16);
           result.write(padWithZeros(number, numberSize));
           break;
         default:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,7 @@
 name: html
-version: 0.14.0+4
+version: 0.15.0-dev
 
 description: APIs for parsing and manipulating HTML content outside the browser.
-author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/html
 
 environment:

--- a/test/parser_feature_test.dart
+++ b/test/parser_feature_test.dart
@@ -13,7 +13,7 @@ void main() {
   _testElementSpans();
   test('doctype is cloneable', () {
     var doc = parse('<!doctype HTML>');
-    DocumentType doctype = doc.nodes[0];
+    final doctype = doc.nodes[0] as DocumentType;
     expect(doctype.clone(false).toString(), '<!DOCTYPE html>');
   });
 
@@ -86,7 +86,7 @@ On line 4, column 3 of ParseError: Unexpected DOCTYPE. Ignored.
     var textContent = '\n  hello {{name}}';
     var html = '<body><div>$textContent</div>';
     var doc = parse(html, generateSpans: true);
-    Text text = doc.body.nodes[0].nodes[0];
+    final text = doc.body.nodes[0].nodes[0] as Text;
     expect(text, const TypeMatcher<Text>());
     expect(text.data, textContent);
     expect(text.sourceSpan.start.offset, html.indexOf(textContent));
@@ -186,35 +186,35 @@ On line 4, column 3 of ParseError: Unexpected DOCTYPE. Ignored.
     });
 
     test('escaping Text node in <script>', () {
-      Element e = parseFragment('<script>a && b</script>').firstChild;
+      final e = parseFragment('<script>a && b</script>').firstChild as Element;
       expect(e.outerHtml, '<script>a && b</script>');
     });
 
     test('escaping Text node in <span>', () {
-      Element e = parseFragment('<span>a && b</span>').firstChild;
+      final e = parseFragment('<span>a && b</span>').firstChild as Element;
       expect(e.outerHtml, '<span>a &amp;&amp; b</span>');
     });
 
     test('Escaping attributes', () {
-      Element e = parseFragment('<div class="a<b>">').firstChild;
+      var e = parseFragment('<div class="a<b>">').firstChild as Element;
       expect(e.outerHtml, '<div class="a<b>"></div>');
-      e = parseFragment('<div class=\'a"b\'>').firstChild;
+      e = parseFragment('<div class=\'a"b\'>').firstChild as Element;
       expect(e.outerHtml, '<div class="a&quot;b"></div>');
     });
 
     test('Escaping non-breaking space', () {
       var text = '<span>foO\u00A0bar</span>';
       expect(text.codeUnitAt(text.indexOf('O') + 1), 0xA0);
-      Element e = parseFragment(text).firstChild;
+      var e = parseFragment(text).firstChild as Element;
       expect(e.outerHtml, '<span>foO&nbsp;bar</span>');
     });
 
     test('Newline after <pre>', () {
-      Element e = parseFragment('<pre>\n\nsome text</span>').firstChild;
+      var e = parseFragment('<pre>\n\nsome text</span>').firstChild as Element;
       expect((e.firstChild as Text).data, '\nsome text');
       expect(e.outerHtml, '<pre>\n\nsome text</pre>');
 
-      e = parseFragment('<pre>\nsome text</span>').firstChild;
+      e = parseFragment('<pre>\nsome text</span>').firstChild as Element;
       expect((e.firstChild as Text).data, 'some text');
       expect(e.outerHtml, '<pre>some text</pre>');
     });
@@ -278,7 +278,7 @@ On line 4, column 3 of ParseError: Unexpected DOCTYPE. Ignored.
   test('Text.text', () {
     var doc = parseFragment('<div>foo<div>bar</div>baz</div>');
     var e = doc.firstChild;
-    Text text = e.firstChild;
+    final text = e.firstChild as Text;
     expect(text.data, 'foo');
     expect(text.text, 'foo');
 

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -79,12 +79,10 @@ void main() {
     group(testName, () {
       for (var testData in tests) {
         var input = testData['data'];
-        var errors = testData['errors'];
+        final errorString = testData['errors'];
+        final errors = errorString?.split('\n');
         var innerHTML = testData['document-fragment'];
         var expected = testData['document'];
-        if (errors != null) {
-          errors = errors.split('\n');
-        }
 
         for (var treeCtor in treeTypes.values) {
           for (var namespaceHTMLElements in const [false, true]) {

--- a/test/selectors/level1_lib.dart
+++ b/test/selectors/level1_lib.dart
@@ -28,8 +28,7 @@ void setupSpecialElements(parent) {
   anyNS.id = 'any-namespace';
   noNS.id = 'no-namespace';
 
-  var div;
-  div = [
+  var div = [
     doc.createElement('div'),
     doc.createElementNS('http://www.w3.org/1999/xhtml', 'div'),
     doc.createElementNS('', 'div'),
@@ -70,7 +69,7 @@ void setupSpecialElements(parent) {
 /*
  * Check that the querySelector and querySelectorAll methods exist on the given Node
  */
-void interfaceCheck(type, obj) {
+void interfaceCheck(String type, obj) {
   runTest(() {
     var q = obj.querySelector is Function;
     assertTrue(q, type + ' supports querySelector.');
@@ -94,7 +93,7 @@ void interfaceCheck(type, obj) {
  * Verify that the NodeList returned by querySelectorAll is static and and that a new list is created after
  * each call. A static list should not be affected by subsequent changes to the DOM.
  */
-void verifyStaticList(type, root) {
+void verifyStaticList(String type, root) {
   var pre, post, preLength;
 
   runTest(() {
@@ -119,7 +118,7 @@ void verifyStaticList(type, root) {
  * Verify handling of special values for the selector parameter, including stringification of
  * null and undefined, and the handling of the empty string.
  */
-void runSpecialSelectorTests(type, root) {
+void runSpecialSelectorTests(String type, root) {
   // Dart note: changed these tests because we don't have auto conversion to
   // String like JavaScript does.
   runTest(() {
@@ -170,7 +169,7 @@ void runSpecialSelectorTests(type, root) {
     // 7
     var result = root.querySelectorAll('*');
     var i = 0;
-    traverse(root, (elem) {
+    traverse(root as Node, (elem) {
       if (!identical(elem, root)) {
         assertEquals(
             elem, result[i], 'The result in index $i should be in tree order.');
@@ -197,7 +196,7 @@ String _getSkip(String name) {
 void runValidSelectorTest(String type, root,
     List<Map<String, dynamic>> selectors, testType, docType) {
   var nodeType = '';
-  switch (root.nodeType) {
+  switch ((root as Node).nodeType) {
     case Node.DOCUMENT_NODE:
       nodeType = 'document';
       break;
@@ -213,20 +212,21 @@ void runValidSelectorTest(String type, root,
 
   for (var i = 0; i < selectors.length; i++) {
     var s = selectors[i];
-    var n = s['name'];
+    var n = s['name'] as String;
     var skip = _getSkip(n);
-    var q = s['selector'];
-    var e = s['expect'];
+    var q = s['selector'] as String;
+    var e = s['expect'] as List;
 
     if ((s['exclude'] is! List ||
             (s['exclude'].indexOf(nodeType) == -1 &&
                 s['exclude'].indexOf(docType) == -1)) &&
         (s['testType'] & testType != 0)) {
       //console.log("Running tests " + nodeType + ": " + s["testType"] + "&" + testType + "=" + (s["testType"] & testType) + ": " + JSON.stringify(s))
-      var foundall, found;
+      List<Element> foundall;
+      Element found;
 
       runTest(() {
-        foundall = root.querySelectorAll(q);
+        foundall = root.querySelectorAll(q) as List<Element>;
         assertNotEquals(foundall, null, 'The method should not return null.');
         assertEquals(foundall.length, e.length,
             'The method should return the expected number of matches.');
@@ -242,7 +242,7 @@ void runValidSelectorTest(String type, root,
       }, type + '.querySelectorAll: ' + n + ': ' + q, skip: skip);
 
       runTest(() {
-        found = root.querySelector(q);
+        found = root.querySelector(q) as Element;
 
         if (e.isNotEmpty) {
           assertNotEquals(found, null, 'The method should return a match.');
@@ -269,8 +269,8 @@ void runValidSelectorTest(String type, root,
 void runInvalidSelectorTest(String type, root, List selectors) {
   for (var i = 0; i < selectors.length; i++) {
     var s = selectors[i];
-    var n = s['name'];
-    var q = s['selector'];
+    var n = s['name'] as String;
+    var q = s['selector'] as String;
 
     // Dart note: FormatException seems a reasonable mapping of SyntaxError
     runTest(() {
@@ -298,7 +298,7 @@ void traverse(Node elem, void Function(Node) fn) {
   }
 }
 
-void runTest(Function body, String name, {String skip}) =>
+void runTest(dynamic Function() body, String name, {String skip}) =>
     unittest.test(name, body, skip: skip);
 
 void assertTrue(bool value, String reason) =>


### PR DESCRIPTION
This will make it easier to migrate to null safety which also disables
implicit casts except from dynamic. Also fix the implicit casts from
dynamic since this package has a lot of dynamic code that is harder to
read with implicit casts.

- Add argument types to some signatures that should have had them from
  the start.
- Add explicit casts.
- Extract a few new local variables to make some of the casts only need
  to happen once.
- Use `Iterable.whereType` in a loop instead of a type check and
  `continue` in the loop body.