### PR TITLE
Remove unused field _lineStarts

### DIFF
--- a/lib/src/html_input_stream.dart
+++ b/lib/src/html_input_stream.dart
@@ -39,8 +39,6 @@ class HtmlInputStream {
 
   SourceFile fileInfo;
 
-  List<int> _lineStarts;
-
   List<int> _chars;
 
   int _offset;
@@ -88,7 +86,6 @@ class HtmlInputStream {
     errors = Queue<String>();
 
     _offset = 0;
-    _lineStarts = <int>[0];
     _chars = <int>[];
 
     _rawChars ??= _decodeBytes(charEncodingName, _rawBytes);
@@ -120,7 +117,6 @@ class HtmlInputStream {
       }
 
       _chars.add(c);
-      if (c == NEWLINE) _lineStarts.add(_chars.length);
     }
 
     // Free decoded characters if they aren't needed anymore.


### PR DESCRIPTION
The usage of this field was removed in
https://github.com/dart-lang/html/commit/eaca2abbf149ab4d280ae94cb6e67480db421c0e