### PR TITLE
Use Object in place of dynamic

### DIFF
--- a/lib/dom.dart
+++ b/lib/dom.dart
@@ -55,7 +55,7 @@ class AttributeName implements Comparable<Object> {
   }
 
   @override
-  int compareTo(dynamic other) {
+  int compareTo(Object other) {
     // Not sure about this sort order
     if (other is! AttributeName) return 1;
     final otherAttributeName = other as AttributeName;
@@ -152,7 +152,7 @@ abstract class Node {
   ///
   /// Note that attribute order needs to be stable for serialization, so we use
   /// a LinkedHashMap. Each key is a [String] or [AttributeName].
-  LinkedHashMap<dynamic, String> attributes = LinkedHashMap();
+  LinkedHashMap<Object, String> attributes = LinkedHashMap();
 
   /// A list of child nodes of the current node. This must
   /// include all elements but not necessarily other node types.
@@ -166,8 +166,8 @@ abstract class Node {
   FileSpan sourceSpan;
 
   /// The attribute spans if requested. Otherwise null.
-  LinkedHashMap<dynamic, FileSpan> _attributeSpans;
-  LinkedHashMap<dynamic, FileSpan> _attributeValueSpans;
+  LinkedHashMap<Object, FileSpan> _attributeSpans;
+  LinkedHashMap<Object, FileSpan> _attributeValueSpans;
 
   Node._() {
     nodes._parent = this;
@@ -177,7 +177,7 @@ abstract class Node {
   /// The span of an attribute is the entire attribute, including the name and
   /// quotes (if any). For example, the span of "attr" in `<a attr="value">`
   /// would be the text `attr="value"`.
-  LinkedHashMap<dynamic, FileSpan> get attributeSpans {
+  LinkedHashMap<Object, FileSpan> get attributeSpans {
     _ensureAttributeSpans();
     return _attributeSpans;
   }
@@ -186,7 +186,7 @@ abstract class Node {
   /// value. Unlike [attributeSpans], this span will inlcude only the value.
   /// For example, the value span of "attr" in `<a attr="value">` would be the
   /// text `value`.
-  LinkedHashMap<dynamic, FileSpan> get attributeValueSpans {
+  LinkedHashMap<Object, FileSpan> get attributeValueSpans {
     _ensureAttributeSpans();
     return _attributeValueSpans;
   }
@@ -279,8 +279,8 @@ abstract class Node {
   void _ensureAttributeSpans() {
     if (_attributeSpans != null) return;
 
-    _attributeSpans = LinkedHashMap<dynamic, FileSpan>();
-    _attributeValueSpans = LinkedHashMap<dynamic, FileSpan>();
+    _attributeSpans = LinkedHashMap<Object, FileSpan>();
+    _attributeValueSpans = LinkedHashMap<Object, FileSpan>();
 
     if (sourceSpan == null) return;
 
@@ -421,7 +421,7 @@ class Text extends Node {
   /// The text node's data, stored as either a String or StringBuffer.
   /// We support storing a StringBuffer here to support fast [appendData].
   /// It will flatten back to a String on read.
-  dynamic _data;
+  Object _data;
 
   Text(String data)
       : _data = data ?? '',

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -1819,8 +1819,7 @@ class InBodyPhase extends Phase {
       formAttrs['action'] = dataAction;
     }
     processStartTag(StartTagToken('form', data: formAttrs));
-    processStartTag(
-        StartTagToken('hr', data: LinkedHashMap<Object, String>()));
+    processStartTag(StartTagToken('hr', data: LinkedHashMap<Object, String>()));
     processStartTag(
         StartTagToken('label', data: LinkedHashMap<Object, String>()));
     // XXX Localization ...
@@ -1834,8 +1833,7 @@ class InBodyPhase extends Phase {
     processStartTag(StartTagToken('input',
         data: attributes, selfClosing: token.selfClosing));
     processEndTag(EndTagToken('label'));
-    processStartTag(
-        StartTagToken('hr', data: LinkedHashMap<Object, String>()));
+    processStartTag(StartTagToken('hr', data: LinkedHashMap<Object, String>()));
     processEndTag(EndTagToken('form'));
   }
 
@@ -1938,8 +1936,7 @@ class InBodyPhase extends Phase {
 
   void endTagP(EndTagToken token) {
     if (!tree.elementInScope('p', variant: 'button')) {
-      startTagCloseP(
-          StartTagToken('p', data: LinkedHashMap<Object, String>()));
+      startTagCloseP(StartTagToken('p', data: LinkedHashMap<Object, String>()));
       parser.parseError(token.span, 'unexpected-end-tag', {'name': 'p'});
       endTagP(EndTagToken('p'));
     } else {

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -826,7 +826,7 @@ class BeforeHtmlPhase extends Phase {
   // helper methods
   void insertHtmlElement() {
     tree.insertRoot(
-        StartTagToken('html', data: LinkedHashMap<dynamic, String>()));
+        StartTagToken('html', data: LinkedHashMap<Object, String>()));
     parser.phase = parser._beforeHeadPhase;
   }
 
@@ -913,7 +913,7 @@ class BeforeHeadPhase extends Phase {
 
   @override
   bool processEOF() {
-    startTagHead(StartTagToken('head', data: LinkedHashMap<dynamic, String>()));
+    startTagHead(StartTagToken('head', data: LinkedHashMap<Object, String>()));
     return true;
   }
 
@@ -924,7 +924,7 @@ class BeforeHeadPhase extends Phase {
 
   @override
   Token processCharacters(CharactersToken token) {
-    startTagHead(StartTagToken('head', data: LinkedHashMap<dynamic, String>()));
+    startTagHead(StartTagToken('head', data: LinkedHashMap<Object, String>()));
     return token;
   }
 
@@ -940,12 +940,12 @@ class BeforeHeadPhase extends Phase {
   }
 
   Token startTagOther(StartTagToken token) {
-    startTagHead(StartTagToken('head', data: LinkedHashMap<dynamic, String>()));
+    startTagHead(StartTagToken('head', data: LinkedHashMap<Object, String>()));
     return token;
   }
 
   Token endTagImplyHead(EndTagToken token) {
-    startTagHead(StartTagToken('head', data: LinkedHashMap<dynamic, String>()));
+    startTagHead(StartTagToken('head', data: LinkedHashMap<Object, String>()));
     return token;
   }
 
@@ -1209,7 +1209,7 @@ class AfterHeadPhase extends Phase {
 
   void anythingElse() {
     tree.insertElement(
-        StartTagToken('body', data: LinkedHashMap<dynamic, String>()));
+        StartTagToken('body', data: LinkedHashMap<Object, String>()));
     parser.phase = parser._inBodyPhase;
     parser.framesetOK = true;
   }
@@ -1813,21 +1813,21 @@ class InBodyPhase extends Phase {
     if (tree.formPointer != null) {
       return;
     }
-    final formAttrs = LinkedHashMap<dynamic, String>();
+    final formAttrs = LinkedHashMap<Object, String>();
     final dataAction = token.data['action'];
     if (dataAction != null) {
       formAttrs['action'] = dataAction;
     }
     processStartTag(StartTagToken('form', data: formAttrs));
     processStartTag(
-        StartTagToken('hr', data: LinkedHashMap<dynamic, String>()));
+        StartTagToken('hr', data: LinkedHashMap<Object, String>()));
     processStartTag(
-        StartTagToken('label', data: LinkedHashMap<dynamic, String>()));
+        StartTagToken('label', data: LinkedHashMap<Object, String>()));
     // XXX Localization ...
     var prompt = token.data['prompt'];
     prompt ??= 'This is a searchable index. Enter search keywords: ';
     processCharacters(CharactersToken(prompt));
-    final attributes = LinkedHashMap<dynamic, String>.from(token.data);
+    final attributes = LinkedHashMap<Object, String>.from(token.data);
     attributes.remove('action');
     attributes.remove('prompt');
     attributes['name'] = 'isindex';
@@ -1835,7 +1835,7 @@ class InBodyPhase extends Phase {
         data: attributes, selfClosing: token.selfClosing));
     processEndTag(EndTagToken('label'));
     processStartTag(
-        StartTagToken('hr', data: LinkedHashMap<dynamic, String>()));
+        StartTagToken('hr', data: LinkedHashMap<Object, String>()));
     processEndTag(EndTagToken('form'));
   }
 
@@ -1939,7 +1939,7 @@ class InBodyPhase extends Phase {
   void endTagP(EndTagToken token) {
     if (!tree.elementInScope('p', variant: 'button')) {
       startTagCloseP(
-          StartTagToken('p', data: LinkedHashMap<dynamic, String>()));
+          StartTagToken('p', data: LinkedHashMap<Object, String>()));
       parser.parseError(token.span, 'unexpected-end-tag', {'name': 'p'});
       endTagP(EndTagToken('p'));
     } else {
@@ -2238,7 +2238,7 @@ class InBodyPhase extends Phase {
         {'originalName': 'br', 'newName': 'br element'});
     tree.reconstructActiveFormattingElements();
     tree.insertElement(
-        StartTagToken('br', data: LinkedHashMap<dynamic, String>()));
+        StartTagToken('br', data: LinkedHashMap<Object, String>()));
     tree.openElements.removeLast();
   }
 
@@ -2450,7 +2450,7 @@ class InTablePhase extends Phase {
 
   Token startTagCol(StartTagToken token) {
     startTagColgroup(
-        StartTagToken('colgroup', data: LinkedHashMap<dynamic, String>()));
+        StartTagToken('colgroup', data: LinkedHashMap<Object, String>()));
     return token;
   }
 
@@ -2462,7 +2462,7 @@ class InTablePhase extends Phase {
 
   Token startTagImplyTbody(StartTagToken token) {
     startTagRowGroup(
-        StartTagToken('tbody', data: LinkedHashMap<dynamic, String>()));
+        StartTagToken('tbody', data: LinkedHashMap<Object, String>()));
     return token;
   }
 
@@ -2918,7 +2918,7 @@ class InTableBodyPhase extends Phase {
   Token startTagTableCell(StartTagToken token) {
     parser.parseError(
         token.span, 'unexpected-cell-in-table-body', {'name': token.name});
-    startTagTr(StartTagToken('tr', data: LinkedHashMap<dynamic, String>()));
+    startTagTr(StartTagToken('tr', data: LinkedHashMap<Object, String>()));
     return token;
   }
 

--- a/lib/src/token.dart
+++ b/lib/src/token.dart
@@ -22,7 +22,7 @@ abstract class TagToken extends Token {
 class StartTagToken extends TagToken {
   /// The tag's attributes. A map from the name to the value, where the name
   /// can be a [String] or [AttributeName].
-  LinkedHashMap<dynamic, String> data;
+  LinkedHashMap<Object, String> data;
 
   /// The attribute spans if requested. Otherwise null.
   List<TagAttribute> attributeSpans;

--- a/test/parser_feature_test.dart
+++ b/test/parser_feature_test.dart
@@ -231,10 +231,13 @@ On line 4, column 3 of ParseError: Unexpected DOCTYPE. Ignored.
       ''');
       final n = doc.querySelector('desc');
       final keys = n.attributes.keys.toList();
-      expect(keys[0], const TypeMatcher<AttributeName>());
-      expect(keys[0].prefix, 'xlink');
-      expect(keys[0].namespace, 'http://www.w3.org/1999/xlink');
-      expect(keys[0].name, 'type');
+      expect(
+          keys.first,
+          isA<AttributeName>()
+              .having((n) => n.prefix, 'prefix', 'xlink')
+              .having((n) => n.namespace, 'namespace',
+                  'http://www.w3.org/1999/xlink')
+              .having((n) => n.name, 'name', 'type'));
 
       expect(
           n.outerHtml,


### PR DESCRIPTION
Replace fields and Map keys with `Object` where they were previously
`dynamic`.