### PR TITLE
Drop unused lastPhase and beforeRcDataPhase fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.15.0-dev
 
+- Drop `HtmlParser.lastPhase` and `HtmlParser.beforeRcDataPhase`. These fields
+  never had a value other than `null`.
+
 ## 0.14.0+4
 
 - Fix a bug parsing bad HTML where a 'button' end tag needs to close other

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -93,11 +93,7 @@ class HtmlParser {
 
   Phase phase;
 
-  Phase lastPhase;
-
   Phase originalPhase;
-
-  Phase beforeRCDataPhase;
 
   bool framesetOK;
 
@@ -252,8 +248,6 @@ class HtmlParser {
       phase = _initialPhase;
     }
 
-    lastPhase = null;
-    beforeRCDataPhase = null;
     framesetOK = true;
   }
 


### PR DESCRIPTION
These fields are unused in both this library and the python library from
which it was transliterated. The `lastPhase` was later named to
`originalPhase` but not all references were cleaned up which leaves one
remaining assignment to null. `beforeRcDataPhase` was unused in the
commit which introduced it and never assigned an interesting value or
read the field.