### PR TITLE
Remove a fixed size list creation

### DIFF
--- a/test/support.dart
+++ b/test/support.dart
@@ -110,7 +110,7 @@ class TestSerializer extends TreeVisitor {
 
   set indent(int value) {
     if (_indent == value) return;
-    _spaces = ' '*value;
+    _spaces = ' ' * value;
     _indent = value;
   }
 

--- a/test/support.dart
+++ b/test/support.dart
@@ -110,12 +110,7 @@ class TestSerializer extends TreeVisitor {
 
   set indent(int value) {
     if (_indent == value) return;
-
-    final arr = List<int>(value);
-    for (var i = 0; i < value; i++) {
-      arr[i] = 32;
-    }
-    _spaces = String.fromCharCodes(arr);
+    _spaces = ' '*value;
     _indent = value;
   }
 


### PR DESCRIPTION
The dart idiom for a repeated string is `operator *`. Remove an
unnecessary intermediate list and `String.fromCharCodes`.