### PR TITLE
Avoid extra list for single character strings

### DIFF
--- a/lib/src/html_input_stream.dart
+++ b/lib/src/html_input_stream.dart
@@ -248,7 +248,7 @@ class HtmlInputStream {
     // Only one character is allowed to be ungotten at once - it must
     // be consumed again before any further call to unget
     if (ch != null) {
-      _offset -= ch.codeUnits.length;
+      _offset -= ch.length;
       assert(peekChar() == ch);
     }
   }

--- a/lib/src/html_input_stream.dart
+++ b/lib/src/html_input_stream.dart
@@ -209,14 +209,14 @@ class HtmlInputStream {
     if (_offset >= _chars.length) return eof;
     return _isSurrogatePair(_chars, _offset)
         ? String.fromCharCodes([_chars[_offset++], _chars[_offset++]])
-        : String.fromCharCodes([_chars[_offset++]]);
+        : String.fromCharCode(_chars[_offset++]);
   }
 
   String peekChar() {
     if (_offset >= _chars.length) return eof;
     return _isSurrogatePair(_chars, _offset)
         ? String.fromCharCodes([_chars[_offset], _chars[_offset + 1]])
-        : String.fromCharCodes([_chars[_offset]]);
+        : String.fromCharCode(_chars[_offset]);
   }
 
   // Whether the current and next chars indicate a surrogate pair.


### PR DESCRIPTION
When we know the length to be 1, use `String.fromCharCode` instead of
`String.fromCharCodes`.