### PR TITLE
Enable and fix lint comment_references

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -17,7 +17,7 @@ linter:
     - await_only_futures
     - camel_case_types
     - cancel_subscriptions
-    #- comment_references
+    - comment_references
     # See https://github.com/dart-lang/logging/issues/43
     #- constant_identifier_names
     - control_flow_in_finally

--- a/lib/dom.dart
+++ b/lib/dom.dart
@@ -183,7 +183,7 @@ abstract class Node {
   }
 
   /// If [sourceSpan] is available, this contains the spans of each attribute's
-  /// value. Unlike [attributeSpans], this span will inlcude only the value.
+  /// value. Unlike [attributeSpans], this span will include only the value.
   /// For example, the value span of "attr" in `<a attr="value">` would be the
   /// text `value`.
   LinkedHashMap<Object, FileSpan> get attributeValueSpans {
@@ -506,7 +506,7 @@ class Element extends Node with _ParentNode, _ElementAndDocument {
     //    creating them every call.
     // 2) Verify that the html does not contain leading or trailing text nodes.
     // 3) Verify that the html does not contain both <head> and <body> tags.
-    // 4) Detatch the created element from its dummy parent.
+    // 4) Detach the created element from its dummy parent.
     var parentTag = 'div';
     String tag;
     final match = _startTagRegexp.firstMatch(html);

--- a/lib/dom.dart
+++ b/lib/dom.dart
@@ -84,7 +84,7 @@ abstract class _ParentNode implements Node {
   /// [selectors level 4](http://dev.w3.org/csswg/selectors-4/)
   /// are implemented. For example, nth-child does not implement An+B syntax
   /// and *-of-type is not implemented. If a selector is not implemented this
-  /// method will throw [UniplmentedError].
+  /// method will throw [UnimplementedError].
   Element querySelector(String selector) => query.querySelector(this, selector);
 
   /// Returns all descendant nodes matching the given selectors, using a
@@ -94,7 +94,7 @@ abstract class _ParentNode implements Node {
   /// [selectors level 4](http://dev.w3.org/csswg/selectors-4/)
   /// are implemented. For example, nth-child does not implement An+B syntax
   /// and *-of-type is not implemented. If a selector is not implemented this
-  /// method will throw [UniplmentedError].
+  /// method will throw [UnimplementedError].
   List<Element> querySelectorAll(String selector) =>
       query.querySelectorAll(this, selector);
 }
@@ -239,9 +239,10 @@ abstract class Node {
   }
 
   /// Insert [node] as a child of the current node, before [refNode] in the
-  /// list of child nodes. Raises [UnsupportedOperationException] if [refNode]
-  /// is not a child of the current node. If refNode is null, this adds to the
-  /// end of the list.
+  /// list of child nodes.
+  ///
+  /// [refNode] must be a hild of the current node or null. If [refNode] is null
+  /// [node] will be added to the end of the list.
   void insertBefore(Node node, Node refNode) {
     if (refNode == null) {
       nodes.add(node);

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -136,7 +136,7 @@ class HtmlParser {
   /// Set [lowercaseElementName] or [lowercaseAttrName] to false to disable the
   /// automatic conversion of element and attribute names to lower case. Note
   /// that standard way to parse HTML is to lowercase, which is what the browser
-  /// DOM will do if you request [Node.outerHTML], for example.
+  /// DOM will do if you request `Element.outerHTML`, for example.
   HtmlParser(input,
       {String encoding,
       bool parseMeta = true,
@@ -3984,12 +3984,10 @@ class ParseError implements SourceSpanException {
 
   int get column => span.start.column;
 
-  /// Gets the human readable error message for this error. Use
-  /// [span.getLocationMessage] or [toString] to get a message including span
-  /// information. If there is a file associated with the span, both
-  /// [span.getLocationMessage] and [toString] are equivalent. Otherwise,
-  /// [span.getLocationMessage] will not show any source url information, but
-  /// [toString] will include 'ParserError:' as a prefix.
+  /// Returns the human readable error message for this error.
+  ///
+  /// Use [SourceSpan.message] or the [toString] from the [span] field to get a
+  /// message including span information
   @override
   String get message => formatStr(errorMessages[errorCode], data);
 

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -15,9 +15,11 @@ class ReparseException implements Exception {
 
 // TODO(jmesserly): assuming the programmatic name is not important, it would be
 // good to make these "static const" fields on an ErrorMessage class.
-/// These are error messages emitted by [HtmlParser]. The values use Python
-/// style string formatting, as implemented by [formatStr]. That function only
-/// supports the subset of format functionality used here.
+/// Error messages emitted by `HtmlParser`.
+///
+/// The values use Python style string formatting, as implemented by
+/// [formatStr]. That function only supports the subset of format functionality
+/// used here.
 const Map<String, String> errorMessages = {
   'null-character': 'Null character in input stream, replaced with U+FFFD.',
   'invalid-codepoint': 'Invalid codepoint in stream.',

--- a/lib/src/html_input_stream.dart
+++ b/lib/src/html_input_stream.dart
@@ -43,13 +43,13 @@ class HtmlInputStream {
 
   int _offset;
 
-  /// Initialises the HtmlInputStream.
+  /// Initialise an HtmlInputStream.
   ///
   /// HtmlInputStream(source, [encoding]) -> Normalized stream from source
   /// for use by html5lib.
   ///
   /// [source] can be either a [String] or a [List<int>] containing the raw
-  /// bytes, or a file if [consoleSupport] is initialized.
+  /// bytes.
   ///
   /// The optional encoding parameter must be a string that indicates
   /// the encoding.  If specified, that encoding will be used,

--- a/lib/src/token.dart
+++ b/lib/src/token.dart
@@ -21,7 +21,7 @@ abstract class TagToken extends Token {
 
 class StartTagToken extends TagToken {
   /// The tag's attributes. A map from the name to the value, where the name
-  /// can be a [String] or [AttributeName].
+  /// can be a [String] or `AttributeName`.
   LinkedHashMap<Object, String> data;
 
   /// The attribute spans if requested. Otherwise null.


### PR DESCRIPTION
Fix some typos and reference to deleted or renamed members. Rephrase
some docs that were not following best practices.