### PR TITLE
Find test data files from package: URI

### DIFF
--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -69,8 +69,8 @@ void runParserTest(
   }
 }
 
-void main() {
-  for (var path in getDataFiles('tree-construction')) {
+void main() async {
+  await for (var path in dataFiles('tree-construction')) {
     if (!path.endsWith('.dat')) continue;
 
     final tests = TestData(path, 'data');

--- a/test/selectors/level1_baseline_test.dart
+++ b/test/selectors/level1_baseline_test.dart
@@ -17,15 +17,16 @@ import '../support.dart';
 import 'level1_lib.dart';
 import 'selectors.dart';
 
-Document getTestContentDocument() {
-  final testPath = p.join(testDir, 'selectors', 'level1-content.html');
+Future<Document> testContentDocument() async {
+  final testPath =
+      p.join(await testDirectory, 'selectors', 'level1-content.html');
   return parse(File(testPath).readAsStringSync());
 }
 
 var testType = testQsaBaseline; // Only run baseline tests.
 var docType = 'html'; // Only run tests suitable for HTML
 
-void main() {
+void main() async {
   /*
    * This test suite tests Selectors API methods in 4 different contexts:
    * 1. Document node
@@ -62,7 +63,7 @@ void main() {
 
   // Prepare the nodes for testing
   //doc = frame.contentDocument;                 // Document Node tests
-  doc = getTestContentDocument();
+  doc = await testContentDocument();
 
   final element = doc.getElementById('root'); // In-document Element Node tests
 

--- a/test/support.dart
+++ b/test/support.dart
@@ -22,8 +22,9 @@ Map<String, TreeBuilderFactory> get treeTypes {
 Future<String> get testDirectory async {
   final packageUriDir = p.dirname(p.fromUri(await Isolate.resolvePackageUri(
       Uri(scheme: 'package', path: 'html/html.dart'))));
-  // Assume pub layout - root is parent directory to package URI.
-  return p.join(p.dirname(packageUriDir), 'test');
+  // Assume pub layout - root is parent directory to package URI (`lib/`).
+  final rootPackageDir = p.dirname(packageUriDir);
+  return p.join(rootPackageDir, 'test');
 }
 
 Stream<String> dataFiles(String subdirectory) async* {

--- a/test/support.dart
+++ b/test/support.dart
@@ -3,6 +3,7 @@ library support;
 
 import 'dart:collection';
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:path/path.dart' as p;
 import 'package:html/src/treebuilder.dart';
@@ -18,13 +19,19 @@ Map<String, TreeBuilderFactory> get treeTypes {
   return _treeTypes;
 }
 
-final testDir = p.join(p.dirname(p.fromUri(Platform.packageConfig)), 'test');
+Future<String> get testDirectory async {
+  final packageUriDir = p.dirname(p.fromUri(await Isolate.resolvePackageUri(
+      Uri(scheme: 'package', path: 'html/html.dart'))));
+  // Assume pub layout - root is parent directory to package URI.
+  return p.join(p.dirname(packageUriDir), 'test');
+}
 
-final testDataDir = p.join(testDir, 'data');
-
-Iterable<String> getDataFiles(String subdirectory) {
-  final dir = Directory(p.join(testDataDir, subdirectory));
-  return dir.listSync().whereType<File>().map((f) => f.path);
+Stream<String> dataFiles(String subdirectory) async* {
+  final dir = Directory(p.join(await testDirectory, 'data', subdirectory));
+  await for (final file in dir.list()) {
+    if (file is! File) continue;
+    yield file.path;
+  }
 }
 
 // TODO(jmesserly): make this class simpler. We could probably split on

--- a/test/tokenizer_test.dart
+++ b/test/tokenizer_test.dart
@@ -258,8 +258,8 @@ String camelCase(String s) {
   return result.toString();
 }
 
-void main() {
-  for (var path in getDataFiles('tokenizer')) {
+void main() async {
+  await for (var path in dataFiles('tokenizer')) {
     if (!path.endsWith('.test')) continue;
 
     final text = File(path).readAsStringSync();


### PR DESCRIPTION
In Dart 2.12 the `Platform.packageConfig` changes from `.packages` to
`.dart_tool/package_config.json` which causes the data file discovery to
fail. Switch to resolving a `package:html` URI and assuming the pub
package layout which is more reliable and stable than the package config
file location.

- Migrate from `Platform.packageConfig` to `Isolate.resolvePackageUri`.
- Change the utility methods to be asynchronous and update the `main`
  for tests to `async`.
- Rename from `testDir` to `testDirectory`.
- Rename methods away from `get*`