### PR TITLE
feat: add `limit` parameter to `querySelectorAll`

### DIFF
--- a/lib/dom.dart
+++ b/lib/dom.dart
@@ -95,8 +95,8 @@ abstract class _ParentNode implements Node {
   /// are implemented. For example, nth-child does not implement An+B syntax
   /// and *-of-type is not implemented. If a selector is not implemented this
   /// method will throw [UnimplementedError].
-  List<Element> querySelectorAll(String selector) =>
-      query.querySelectorAll(this, selector);
+  List<Element> querySelectorAll(String selector, {int? limit}) =>
+      query.querySelectorAll(this, selector, limit: limit);
 }
 
 // http://dom.spec.whatwg.org/#interface-nonelementparentnode

--- a/lib/src/query_selector.dart
+++ b/lib/src/query_selector.dart
@@ -13,10 +13,14 @@ bool matches(Element node, String selector) =>
 Element? querySelector(Node node, String selector) =>
     SelectorEvaluator().querySelector(node, _parseSelectorList(selector));
 
-List<Element> querySelectorAll(Node node, String selector) {
+List<Element> querySelectorAll(Node node, String selector, {int? limit}) {
   final results = <Element>[];
-  SelectorEvaluator()
-      .querySelectorAll(node, _parseSelectorList(selector), results);
+  SelectorEvaluator().querySelectorAll(
+    node,
+    _parseSelectorList(selector),
+    results,
+    limit: limit,
+  );
   return results;
 }
 
@@ -49,10 +53,15 @@ class SelectorEvaluator extends Visitor {
   }
 
   void querySelectorAll(
-      Node root, SelectorGroup selector, List<Element> results) {
+    Node root,
+    SelectorGroup selector,
+    List<Element> results, {
+    int? limit,
+  }) {
     for (var element in root.nodes.whereType<Element>()) {
+      if (limit != null && results.length == limit) return;
       if (matches(element, selector)) results.add(element);
-      querySelectorAll(element, selector, results);
+      querySelectorAll(element, selector, results, limit: limit);
     }
   }
 


### PR DESCRIPTION
If you want only a first few results then having `limit` parameter is significantly faster than iterating wastefully the whole tree.

I've created a quick example with benchmark https://github.com/mzdm/dart_html_limit_perf_test

For example on this page https://en.wikipedia.org/wiki/Earth you would want to get first 4 title names.
old way - `document.querySelectorAll('.mw-headline').take(4).toList();` would take **BenchHtml(RunTime): 81102.96 us.**
new way - `document.querySelectorAll('.mw-headline', limit: 4);` - would take **BenchHtmlLimit(RunTime): 7417.951851851852 us.** (~10x times less)

If this is OK approach then I can add some tests.