### PR TITLE
Move htmlSerializeEscape into its own library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.15.1-dev
 
+- Move `htmlSerializeEscape` to its own library,
+  `package:html/html_escape.dart`, which is exported from
+  `package:html/dom_parsing.dart`.
+
 ## 0.15.0
 
 - Migrate to null safety.

--- a/lib/dom_parsing.dart
+++ b/lib/dom_parsing.dart
@@ -3,7 +3,11 @@
 library dom_parsing;
 
 import 'dom.dart';
+import 'html_escape.dart';
 import 'src/constants.dart' show rcdataElements;
+
+// Export a function which was previously declared here.
+export 'html_escape.dart';
 
 /// A simple tree visitor for the DOM nodes.
 class TreeVisitor {
@@ -114,58 +118,6 @@ class CodeMarkupVisitor extends TreeVisitor {
     final data = htmlSerializeEscape(node.data!);
     _str.write('<code class="markup comment">&lt;!--$data--></code>');
   }
-}
-
-// TODO(jmesserly): reconcile this with dart:web htmlEscape.
-// This one might be more useful, as it is HTML5 spec compliant.
-/// Escapes [text] for use in the
-/// [HTML fragment serialization algorithm][1]. In particular, as described
-/// in the [specification][2]:
-///
-/// - Replace any occurrence of the `&` character by the string `&amp;`.
-/// - Replace any occurrences of the U+00A0 NO-BREAK SPACE character by the
-///   string `&nbsp;`.
-/// - If the algorithm was invoked in [attributeMode], replace any occurrences
-///   of the `"` character by the string `&quot;`.
-/// - If the algorithm was not invoked in [attributeMode], replace any
-///   occurrences of the `<` character by the string `&lt;`, and any occurrences
-///   of the `>` character by the string `&gt;`.
-///
-/// [1]: http://www.whatwg.org/specs/web-apps/current-work/multipage/the-end.html#serializing-html-fragments
-/// [2]: http://www.whatwg.org/specs/web-apps/current-work/multipage/the-end.html#escapingString
-String htmlSerializeEscape(String text, {bool attributeMode = false}) {
-  // TODO(jmesserly): is it faster to build up a list of codepoints?
-  // StringBuffer seems cleaner assuming Dart can unbox 1-char strings.
-  StringBuffer? result;
-  for (var i = 0; i < text.length; i++) {
-    final ch = text[i];
-    String? replace;
-    switch (ch) {
-      case '&':
-        replace = '&amp;';
-        break;
-      case '\u00A0' /*NO-BREAK SPACE*/ :
-        replace = '&nbsp;';
-        break;
-      case '"':
-        if (attributeMode) replace = '&quot;';
-        break;
-      case '<':
-        if (!attributeMode) replace = '&lt;';
-        break;
-      case '>':
-        if (!attributeMode) replace = '&gt;';
-        break;
-    }
-    if (replace != null) {
-      result ??= StringBuffer(text.substring(0, i));
-      result.write(replace);
-    } else if (result != null) {
-      result.write(ch);
-    }
-  }
-
-  return result != null ? result.toString() : text;
 }
 
 /// Returns true if this tag name is a void element.

--- a/lib/html_escape.dart
+++ b/lib/html_escape.dart
@@ -1,0 +1,51 @@
+// TODO(jmesserly): reconcile this with dart:web htmlEscape.
+// This one might be more useful, as it is HTML5 spec compliant.
+/// Escapes [text] for use in the
+/// [HTML fragment serialization algorithm][1]. In particular, as described
+/// in the [specification][2]:
+///
+/// - Replace any occurrence of the `&` character by the string `&amp;`.
+/// - Replace any occurrences of the U+00A0 NO-BREAK SPACE character by the
+///   string `&nbsp;`.
+/// - If the algorithm was invoked in [attributeMode], replace any occurrences
+///   of the `"` character by the string `&quot;`.
+/// - If the algorithm was not invoked in [attributeMode], replace any
+///   occurrences of the `<` character by the string `&lt;`, and any occurrences
+///   of the `>` character by the string `&gt;`.
+///
+/// [1]: http://www.whatwg.org/specs/web-apps/current-work/multipage/the-end.html#serializing-html-fragments
+/// [2]: http://www.whatwg.org/specs/web-apps/current-work/multipage/the-end.html#escapingString
+String htmlSerializeEscape(String text, {bool attributeMode = false}) {
+  // TODO(jmesserly): is it faster to build up a list of codepoints?
+  // StringBuffer seems cleaner assuming Dart can unbox 1-char strings.
+  StringBuffer? result;
+  for (var i = 0; i < text.length; i++) {
+    final ch = text[i];
+    String? replace;
+    switch (ch) {
+      case '&':
+        replace = '&amp;';
+        break;
+      case '\u00A0' /*NO-BREAK SPACE*/ :
+        replace = '&nbsp;';
+        break;
+      case '"':
+        if (attributeMode) replace = '&quot;';
+        break;
+      case '<':
+        if (!attributeMode) replace = '&lt;';
+        break;
+      case '>':
+        if (!attributeMode) replace = '&gt;';
+        break;
+    }
+    if (replace != null) {
+      result ??= StringBuffer(text.substring(0, i));
+      result.write(replace);
+    } else if (result != null) {
+      result.write(ch);
+    }
+  }
+
+  return result != null ? result.toString() : text;
+}


### PR DESCRIPTION
This allows build targets to use `htmlSerializeEscape` without bringing in any of `package:html`'s deps.