### PR TITLE
Drop unnecessary severity upgrades

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,10 +5,6 @@ analyzer:
   errors:
     # https://github.com/dart-lang/linter/issues/1649
     prefer_collection_literals: ignore
-    unused_element: error
-    unused_import: error
-    unused_local_variable: error
-    dead_code: error
 linter:
   rules:
     - avoid_dynamic_calls


### PR DESCRIPTION
These are a long outdated legacy pattern which brought external CI more
inline with internal standards where these errors would fail the build.
We are now more strict and the upgrades only impact local development
where they are not useful.