### PR TITLE
Use growable lists and avoid dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Move `htmlSerializeEscape` to its own library,
   `package:html/html_escape.dart`, which is exported from
   `package:html/dom_parsing.dart`.
+- Use more non-growable lists, and type annotations on List literals.
+- Switch analysis option `implicit-casts: false` to `strict-casts: true`.
 
 ## 0.15.0
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,7 @@
 include: package:lints/recommended.yaml
 analyzer:
-  strong-mode:
-    implicit-casts: false
+  language:
+    strict-casts: true
   errors:
     # https://github.com/dart-lang/linter/issues/1649
     prefer_collection_literals: ignore

--- a/lib/dom.dart
+++ b/lib/dom.dart
@@ -885,7 +885,8 @@ class FilteredElementList extends IterableBase<Element>
   //
   // TODO(nweiz): we don't always need to create a new list. For example
   // forEach, every, any, ... could directly work on the _childNodes.
-  List<Element> get _filtered => _childNodes.whereType<Element>().toList();
+  List<Element> get _filtered =>
+      _childNodes.whereType<Element>().toList(growable: false);
 
   @override
   void forEach(void Function(Element) action) {
@@ -1028,7 +1029,7 @@ class FilteredElementList extends IterableBase<Element>
 
   @override
   List<Element> toList({bool growable = true}) =>
-      List<Element>.from(this, growable: growable);
+      List<Element>.of(this, growable: growable);
 
   @override
   Set<Element> toSet() => Set<Element>.from(this);

--- a/lib/dom_parsing.dart
+++ b/lib/dom_parsing.dart
@@ -32,7 +32,7 @@ class TreeVisitor {
 
   void visitChildren(Node node) {
     // Allow for mutations (remove works) while iterating.
-    for (var child in node.nodes.toList()) {
+    for (var child in node.nodes.toList(growable: false)) {
       visit(child);
     }
   }

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -331,7 +331,7 @@ class HtmlParser {
 
     // When the loop finishes it's EOF
     var reprocess = true;
-    final reprocessPhases = [];
+    final reprocessPhases = <Phase>[];
     while (reprocess) {
       reprocessPhases.add(phase);
       reprocess = phase.processEOF();
@@ -430,7 +430,7 @@ class HtmlParser {
       'ychannelselector': 'yChannelSelector',
       'zoomandpan': 'zoomAndPan'
     };
-    for (var originalName in token.data.keys.toList()) {
+    for (var originalName in token.data.keys.toList(growable: false)) {
       final svgName = replacements[originalName as String];
       if (svgName != null) {
         token.data[svgName] = token.data.remove(originalName)!;
@@ -456,7 +456,7 @@ class HtmlParser {
       'xmlns:xlink': AttributeName('xmlns', 'xlink', Namespaces.xmlns)
     };
 
-    for (var originalName in token.data.keys.toList()) {
+    for (var originalName in token.data.keys.toList(growable: false)) {
       final foreignName = replacements[originalName as String];
       if (foreignName != null) {
         token.data[foreignName] = token.data.remove(originalName)!;
@@ -1468,7 +1468,7 @@ class InBodyPhase extends Phase {
     tree.insertElement(token);
     final element = tree.openElements.last;
 
-    final matchingElements = [];
+    final matchingElements = <Node?>[];
     for (Node? node in tree.activeFormattingElements.reversed) {
       if (node == null) {
         break;

--- a/lib/src/encoding_parser.dart
+++ b/lib/src/encoding_parser.dart
@@ -247,8 +247,8 @@ class EncodingParser {
       return null;
     }
     // Step 3
-    final attrName = [];
-    final attrValue = [];
+    final attrName = <String>[];
+    final attrValue = <String>[];
     // Step 4 attribute name
     while (true) {
       if (c == null) {

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -174,7 +174,7 @@ class HtmlTokenizer implements Iterator<Token> {
       radix = 16;
     }
 
-    final charStack = [];
+    final charStack = <String?>[];
 
     // Consume all the characters that are in range while making sure we
     // don't hit an EOF.
@@ -297,8 +297,9 @@ class HtmlTokenizer implements Iterator<Token> {
 
       while (charStack.last != eof) {
         final name = charStack.join();
-        filteredEntityList =
-            filteredEntityList.where((e) => e.startsWith(name)).toList();
+        filteredEntityList = filteredEntityList
+            .where((e) => e.startsWith(name))
+            .toList(growable: false);
 
         if (filteredEntityList.isEmpty) {
           break;

--- a/lib/src/treebuilder.dart
+++ b/lib/src/treebuilder.dart
@@ -111,7 +111,7 @@ class TreeBuilder {
     final exactNode = target is Node;
 
     var listElements1 = scopingElements;
-    var listElements2 = const [];
+    var listElements2 = const <Pair>[];
     var invert = false;
     if (variant != null) {
       switch (variant) {

--- a/test/tokenizer_test.dart
+++ b/test/tokenizer_test.dart
@@ -232,13 +232,13 @@ Map<String, dynamic> unescape(Map<String, dynamic> testInfo) {
   dynamic decode(inp) => inp == '\u0000' ? inp : jsonDecode('"$inp"');
 
   testInfo['input'] = decode(testInfo['input']);
-  for (var token in testInfo['output']) {
+  for (var token in testInfo['output'] as List) {
     if (token == 'ParseError') {
       continue;
     } else {
       token[1] = decode(token[1]);
       if ((token as List).length > 2) {
-        for (var pair in token[2]) {
+        for (var pair in token[2] as List) {
           final key = pair[0];
           final value = pair[1];
           token[2].remove(key);
@@ -276,7 +276,7 @@ void main() async {
         final testInfo = testList[index] as Map<String, dynamic>;
 
         testInfo.putIfAbsent('initialStates', () => ['Data state']);
-        for (var initialState in testInfo['initialStates']) {
+        for (var initialState in testInfo['initialStates'] as List) {
           test(testInfo['description'], () {
             testInfo['initialState'] = camelCase(initialState as String);
             runTokenizerTest(testInfo);


### PR DESCRIPTION
I think these are all related, but I'm happy to split up if desirable.

dartdoc is one of the heavy users of package:html, and we'd like it to be as performant as possible. This change _seems_ to have reduced dartdoc's memory consumption by ~2%, but that could be within the margin of error.

Changes include:

* Use `growable: false` where possible.
* Add type annotations to empty Lists, so they're not `List<dynamic>` (need to enable `strict-raw-types`).
* Flip from `implicit-casts: false` to `strict-casts: true`.
* Replace `List.from` with `List.of`.
* Cast `dynamic` things to `List` before iterating over them in a for loop.