### PR TITLE
finish work for avoid_dynamic_calls

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [2.12.0, dev]
+        sdk: [2.17.0, dev]
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.15.2-dev
+
+- Add additional types at the API boundary (in `lib/parser.dart` and others).
+- Update to `package:lints` 2.0.
+
 ## 0.15.1
 
 - Move `htmlSerializeEscape` to its own library,

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,12 +3,14 @@ include: package:lints/recommended.yaml
 analyzer:
   language:
     strict-casts: true
+    strict-raw-types: true
   errors:
     # https://github.com/dart-lang/linter/issues/1649
     prefer_collection_literals: ignore
 
 linter:
   rules:
+    - always_declare_return_types
     - avoid_dynamic_calls
     - avoid_function_literals_in_foreach_calls
     - avoid_returning_null
@@ -17,14 +19,12 @@ linter:
     - camel_case_types
     - cancel_subscriptions
     - comment_references
-    # See https://github.com/dart-lang/logging/issues/43
-    #- constant_identifier_names
+    - constant_identifier_names
     - control_flow_in_finally
     - directives_ordering
     - empty_statements
     - hash_and_equals
     - implementation_imports
-    #- invariant_booleans
     - iterable_contains_unrelated_type
     - list_remove_unrelated_type
     - no_adjacent_strings_in_list
@@ -41,6 +41,7 @@ linter:
     - prefer_typing_uninitialized_variables
     - test_types_in_equals
     - throw_in_finally
+    - type_annotate_public_apis
     - unnecessary_brace_in_string_interps
     - unnecessary_getters_setters
     - unnecessary_lambdas

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -15,6 +15,7 @@ library parser;
 
 import 'dart:collection';
 import 'dart:math';
+
 import 'package:source_span/source_span.dart';
 
 import 'dom.dart';
@@ -36,7 +37,7 @@ import 'src/utils.dart';
 /// [Node.sourceSpan] property will be `null`. When using [generateSpans] you
 /// can additionally pass [sourceUrl] to indicate where the [input] was
 /// extracted from.
-Document parse(input,
+Document parse(dynamic input,
     {String? encoding, bool generateSpans = false, String? sourceUrl}) {
   final p = HtmlParser(input,
       encoding: encoding, generateSpans: generateSpans, sourceUrl: sourceUrl);
@@ -55,7 +56,7 @@ Document parse(input,
 /// [Node.sourceSpan] property will be `null`. When using [generateSpans] you can
 /// additionally pass [sourceUrl] to indicate where the [input] was extracted
 /// from.
-DocumentFragment parseFragment(input,
+DocumentFragment parseFragment(dynamic input,
     {String container = 'div',
     String? encoding,
     bool generateSpans = false,
@@ -93,7 +94,7 @@ class HtmlParser {
 
   Phase? originalPhase;
 
-  var framesetOK = true;
+  bool framesetOK = true;
 
   // These fields hold the different phase singletons. At any given time one
   // of them will be active.
@@ -140,7 +141,7 @@ class HtmlParser {
   /// automatic conversion of element and attribute names to lower case. Note
   /// that standard way to parse HTML is to lowercase, which is what the browser
   /// DOM will do if you request `Element.outerHTML`, for example.
-  HtmlParser(input,
+  HtmlParser(dynamic input,
       {String? encoding,
       bool parseMeta = true,
       bool lowercaseElementName = true,
@@ -348,7 +349,7 @@ class HtmlParser {
       .pointSpan();
 
   void parseError(SourceSpan? span, String errorcode,
-      [Map? datavars = const {}]) {
+      [Map<String, Object?>? datavars = const {}]) {
     if (!generateSpans && span == null) {
       span = _lastSpan;
     }
@@ -3943,7 +3944,7 @@ class ParseError implements SourceSpanException {
   final String errorCode;
   @override
   final SourceSpan? span;
-  final Map? data;
+  final Map<String, Object?>? data;
 
   ParseError(this.errorCode, this.span, this.data);
 
@@ -3959,7 +3960,7 @@ class ParseError implements SourceSpanException {
   String get message => formatStr(errorMessages[errorCode]!, data);
 
   @override
-  String toString({color}) {
+  String toString({dynamic color}) {
     final res = span!.message(message, color: color);
     return span!.sourceUrl == null ? 'ParserError on $res' : 'On $res';
   }

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -265,7 +265,7 @@ class Namespaces {
   }
 }
 
-const List scopingElements = [
+const List<Pair<String, String>> scopingElements = [
   Pair(Namespaces.html, 'applet'),
   Pair(Namespaces.html, 'caption'),
   Pair(Namespaces.html, 'html'),

--- a/lib/src/html_input_stream.dart
+++ b/lib/src/html_input_stream.dart
@@ -35,7 +35,7 @@ class HtmlInputStream {
   /// Raw UTF-16 codes, used if a Dart String is passed in.
   List<int>? _rawChars;
 
-  var errors = Queue<String>();
+  Queue<String> errors = Queue<String>();
 
   SourceFile? fileInfo;
 
@@ -57,7 +57,7 @@ class HtmlInputStream {
   /// element)
   ///
   /// [parseMeta] - Look for a <meta> element containing encoding information
-  HtmlInputStream(source,
+  HtmlInputStream(dynamic source,
       [String? encoding,
       bool parseMeta = true,
       this.generateSpans = false,

--- a/lib/src/list_proxy.dart
+++ b/lib/src/list_proxy.dart
@@ -22,7 +22,7 @@ abstract class ListProxy<E> extends ListBase<E> {
   E operator [](int index) => _list[index];
 
   @override
-  operator []=(int index, E value) {
+  void operator []=(int index, E value) {
     _list[index] = value;
   }
 

--- a/lib/src/query_selector.dart
+++ b/lib/src/query_selector.dart
@@ -1,9 +1,8 @@
 /// Query selector implementation for our DOM.
 library html.src.query;
 
-import 'package:csslib/parser.dart' as css;
-import 'package:csslib/parser.dart' show TokenKind, Message;
-import 'package:csslib/visitor.dart'; // the CSSOM
+import 'package:csslib/parser.dart';
+import 'package:csslib/visitor.dart';
 import 'package:html/dom.dart';
 import 'package:html/src/constants.dart' show isWhitespaceCC;
 
@@ -23,7 +22,7 @@ List<Element> querySelectorAll(Node node, String selector) {
 // http://dev.w3.org/csswg/selectors-4/#grouping
 SelectorGroup _parseSelectorList(String selector) {
   final errors = <Message>[];
-  final group = css.parseSelectorGroup(selector, errors: errors);
+  final group = parseSelectorGroup(selector, errors: errors);
   if (group == null || errors.isNotEmpty) {
     throw FormatException("'$selector' is not a valid selector: $errors");
   }
@@ -127,7 +126,7 @@ class SelectorEvaluator extends Visitor {
       UnimplementedError("'$selector' selector of type "
           '${selector.runtimeType} is not implemented');
 
-  FormatException _unsupported(selector) =>
+  FormatException _unsupported(TreeNode selector) =>
       FormatException("'$selector' is not a valid selector");
 
   @override

--- a/lib/src/token.dart
+++ b/lib/src/token.dart
@@ -2,6 +2,7 @@
 library token;
 
 import 'dart:collection';
+
 import 'package:source_span/source_span.dart';
 
 /// An html5 token.
@@ -74,7 +75,7 @@ abstract class StringToken extends Token {
 
 class ParseErrorToken extends StringToken {
   /// Extra information that goes along with the error message.
-  Map? messageParams;
+  Map<String, Object?>? messageParams;
 
   ParseErrorToken(String data, {this.messageParams}) : super(data);
 

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -1,7 +1,9 @@
 library tokenizer;
 
 import 'dart:collection';
+
 import 'package:html/parser.dart' show HtmlParser;
+
 import 'constants.dart';
 import 'html_input_stream.dart';
 import 'token.dart';
@@ -63,7 +65,7 @@ class HtmlTokenizer implements Iterator<Token> {
   List<TagAttribute>? _attributes;
   Set<String>? _attributeNames;
 
-  HtmlTokenizer(doc,
+  HtmlTokenizer(dynamic doc,
       {String? encoding,
       bool parseMeta = true,
       this.lowercaseElementName = true,

--- a/lib/src/treebuilder.dart
+++ b/lib/src/treebuilder.dart
@@ -2,9 +2,11 @@
 library treebuilder;
 
 import 'dart:collection';
+
 import 'package:html/dom.dart';
 import 'package:html/parser.dart' show getElementNameTuple;
 import 'package:source_span/source_span.dart';
+
 import 'constants.dart';
 import 'list_proxy.dart';
 import 'token.dart';
@@ -47,7 +49,7 @@ class ActiveFormattingElements extends ListProxy<Element?> {
 }
 
 // TODO(jmesserly): this should exist in corelib...
-bool _mapEquals(Map a, Map b) {
+bool _mapEquals(Map<Object, String> a, Map<Object, String> b) {
   if (a.length != b.length) return false;
   if (a.isEmpty) return true;
 
@@ -85,7 +87,7 @@ class TreeBuilder {
 
   /// Switch the function used to insert an element from the
   /// normal one to the misnested table one and back again
-  var insertFromTable = false;
+  bool insertFromTable = false;
 
   TreeBuilder(bool namespaceHTMLElements)
       : defaultNamespace = namespaceHTMLElements ? Namespaces.html : null {
@@ -105,13 +107,13 @@ class TreeBuilder {
     document = Document();
   }
 
-  bool elementInScope(target, {String? variant}) {
-    //If we pass a node in we match that. if we pass a string
-    //match any node with that name
+  bool elementInScope(dynamic target, {String? variant}) {
+    // If we pass a node in we match that. If we pass a string match any node
+    // with that name.
     final exactNode = target is Node;
 
     var listElements1 = scopingElements;
-    var listElements2 = const <Pair>[];
+    var listElements2 = const <Pair<String, String>>[];
     var invert = false;
     if (variant != null) {
       switch (variant) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -51,7 +51,7 @@ String padWithZeros(String str, int size) {
 /// Format a string like Python's % string format operator. Right now this only
 /// supports a [data] dictionary used with %s or %08x. Those were the only
 /// things needed for [errorMessages].
-String formatStr(String format, Map? data) {
+String formatStr(String format, Map<String, Object?>? data) {
   if (data == null) return format;
   data.forEach((key, value) {
     final result = StringBuffer();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: html
-version: 0.15.1
+version: 0.15.2-dev
 description: APIs for parsing and manipulating HTML content outside the browser.
 repository: https://github.com/dart-lang/html
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   csslib: ^0.17.0
   source_span: ^1.8.0
 
 dev_dependencies:
-  lints: ^1.0.0
+  lints: ^2.0.0
   path: ^1.8.0
   test: ^1.16.0

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -35,7 +35,7 @@ void runParserTest(
     String? innerHTML,
     String? input,
     String? expected,
-    List? errors,
+    List<String>? errors,
     TreeBuilderFactory treeCtor,
     bool namespaceHTMLElements) {
   // XXX - move this out into the setup function

--- a/test/selectors/level1_baseline_test.dart
+++ b/test/selectors/level1_baseline_test.dart
@@ -8,6 +8,7 @@
 library html.test.selectors.level1_baseline_test;
 
 import 'dart:io';
+
 import 'package:html/dom.dart';
 import 'package:html/parser.dart';
 import 'package:path/path.dart' as p;
@@ -23,8 +24,8 @@ Future<Document> testContentDocument() async {
   return parse(File(testPath).readAsStringSync());
 }
 
-var testType = testQsaBaseline; // Only run baseline tests.
-var docType = 'html'; // Only run tests suitable for HTML
+int testType = testQsaBaseline; // Only run baseline tests.
+String docType = 'html'; // Only run tests suitable for HTML
 
 void main() async {
   /*
@@ -88,15 +89,17 @@ void main() async {
   fragment.append(element.clone(true));
 
   // Setup Tests
-  runSpecialSelectorTests('Document', doc);
-  runSpecialSelectorTests('Detached Element', detached);
-  runSpecialSelectorTests('Fragment', fragment);
-  runSpecialSelectorTests('In-document Element', element);
+  runSpecialSelectorTests('Document', SelectorAdaptor.document(doc));
+  runSpecialSelectorTests(
+      'Detached Element', SelectorAdaptor.element(detached));
+  runSpecialSelectorTests('Fragment', SelectorAdaptor.fragment(fragment));
+  runSpecialSelectorTests(
+      'In-document Element', SelectorAdaptor.element(element));
 
-  verifyStaticList('Document', doc);
-  verifyStaticList('Detached Element', detached);
-  verifyStaticList('Fragment', fragment);
-  verifyStaticList('In-document Element', element);
+  verifyStaticList('Document', SelectorAdaptor.document(doc));
+  verifyStaticList('Detached Element', SelectorAdaptor.element(detached));
+  verifyStaticList('Fragment', SelectorAdaptor.fragment(fragment));
+  verifyStaticList('In-document Element', SelectorAdaptor.element(element));
 
   // TODO(jmesserly): fix negative tests
   //runInvalidSelectorTest('Document', doc, invalidSelectors);
@@ -104,10 +107,12 @@ void main() async {
   //runInvalidSelectorTest('Fragment', fragment, invalidSelectors);
   //runInvalidSelectorTest('In-document Element', element, invalidSelectors);
 
-  runValidSelectorTest('Document', doc, validSelectors, testType, docType);
-  runValidSelectorTest(
-      'Detached Element', detached, validSelectors, testType, docType);
-  runValidSelectorTest('Fragment', fragment, validSelectors, testType, docType);
+  runValidSelectorTest('Document', SelectorAdaptor.document(doc),
+      validSelectors, testType, docType);
+  runValidSelectorTest('Detached Element', SelectorAdaptor.element(detached),
+      validSelectors, testType, docType);
+  runValidSelectorTest('Fragment', SelectorAdaptor.fragment(fragment),
+      validSelectors, testType, docType);
 
   group('out of scope', () {
     setUp(() {
@@ -115,7 +120,7 @@ void main() async {
       // None of these elements should match
     });
     tearDown(outOfScope.remove);
-    runValidSelectorTest(
-        'In-document Element', element, validSelectors, testType, docType);
+    runValidSelectorTest('In-document Element',
+        SelectorAdaptor.element(element), validSelectors, testType, docType);
   });
 }

--- a/test/selectors/selectors.dart
+++ b/test/selectors/selectors.dart
@@ -3,16 +3,16 @@
 library html.test.selectors.selectors;
 
 // Bit-mapped flags to indicate which tests the selector is suitable for
-final testQsaBaseline =
+final int testQsaBaseline =
     0x01; // querySelector() and querySelectorAll() baseline tests
-final testQsaAdditional =
+final int testQsaAdditional =
     0x02; // querySelector() and querySelectorAll() additional tests
-final testFindBaseline =
+final int testFindBaseline =
     0x04; // find() and findAll() baseline tests, may be unsuitable for querySelector[All]
-final testFindAdditional =
+final int testFindAdditional =
     0x08; // find() and findAll() additional tests, may be unsuitable for querySelector[All]
-final testMatchBaseline = 0x10; // matches() baseline tests
-var testMatchAdditional = 0x20; // matches() additional tests
+final int testMatchBaseline = 0x10; // matches() baseline tests
+int testMatchAdditional = 0x20; // matches() additional tests
 
 /*
  * All of these invalid selectors should result in a SyntaxError being thrown by the APIs.
@@ -74,7 +74,7 @@ final invalidSelectors = [
  *
  * Note: Interactive pseudo-classes (:active :hover and :focus) have not been tested in this test suite.
  */
-var validSelectors = [
+final List<Map<String, dynamic>> validSelectors = [
   // Type Selector
   {
     'name': 'Type selector, matching html element',
@@ -87,7 +87,7 @@ var validSelectors = [
   {
     'name': 'Type selector, matching html element',
     'selector': 'html',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'exclude': ['document'],
     'level': 1,
     'testType': testQsaBaseline
@@ -103,7 +103,7 @@ var validSelectors = [
   {
     'name': 'Type selector, matching body element',
     'selector': 'body',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'exclude': ['document'],
     'level': 1,
     'testType': testQsaBaseline
@@ -142,7 +142,7 @@ var validSelectors = [
     'name':
         'Universal selector, matching all children of empty element with specified ID',
     'selector': '#empty>*',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -196,7 +196,7 @@ var validSelectors = [
     'name':
         'Attribute presence selector, not matching title attribute, case sensitivity',
     'selector': '#attr-presence [TiTlE]',
-    'expect': [],
+    'expect': <String>[],
     'exclude': ['html'],
     'level': 2,
     'testType': testQsaBaseline | testMatchBaseline
@@ -212,7 +212,7 @@ var validSelectors = [
     'name':
         'Attribute presence selector, not matching attribute with similar name',
     'selector': '.attr-presence-div3[align], .attr-presence-div4[align]',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -228,7 +228,7 @@ var validSelectors = [
     'name':
         'Attribute presence selector, not matching default option without selected attribute',
     'selector': '#attr-presence-select1 option[selected]',
-    'expect': [] /* no matches */,
+    'expect': <String>[] /* no matches */,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -272,7 +272,7 @@ var validSelectors = [
     'name':
         'Attribute value selector, not matching align attribute with partial value',
     'selector': '#attr-value [align="c"]',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -280,7 +280,7 @@ var validSelectors = [
     'name':
         'Attribute value selector, not matching align attribute with incorrect value',
     'selector': '#attr-value [align="centera"]',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -366,7 +366,7 @@ var validSelectors = [
     'name':
         'Attribute whitespace-separated list selector, not matching class attribute with empty value',
     'selector': '#attr-whitespace [class~=""]',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -374,7 +374,7 @@ var validSelectors = [
     'name':
         'Attribute whitespace-separated list selector, not matching class attribute with partial value',
     'selector': '[data-attr-whitespace~="div"]',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -443,7 +443,7 @@ var validSelectors = [
     'name':
         'Attribute whitespace-separated list selector with double-quoted value, not matching value with space',
     'selector': '#attr-whitespace a[rel~="book mark"]',
-    'expect': [] /* no matches */,
+    'expect': <String>[] /* no matches */,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -461,7 +461,7 @@ var validSelectors = [
     'name':
         'Attribute hyphen-separated list selector, not matching unspecified lang attribute',
     'selector': '#attr-hyphen-div1[lang|="en"]',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -485,7 +485,7 @@ var validSelectors = [
     'name':
         'Attribute hyphen-separated list selector, not matching incorrect value',
     'selector': '#attr-hyphen-div4[lang|="es-AR"]',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -511,7 +511,7 @@ var validSelectors = [
     'name':
         'Attribute begins with selector, not matching class attribute not beginning with specified substring',
     'selector': '#attr-begins [class^=apple]',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 3,
     'testType': testQsaAdditional
   },
@@ -535,7 +535,7 @@ var validSelectors = [
     'name':
         'Attribute begins with selector with unquoted value, not matching class attribute not beginning with specified substring',
     'selector': '#attr-begins [class^= apple]',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 3,
     'testType': testQsaAdditional
   },
@@ -561,7 +561,7 @@ var validSelectors = [
     'name':
         'Attribute ends with selector, not matching class attribute not ending with specified substring',
     'selector': '#attr-ends [class\$=apple]',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 3,
     'testType': testQsaAdditional
   },
@@ -585,7 +585,7 @@ var validSelectors = [
     'name':
         'Attribute ends with selector with unquoted value, not matching class attribute not ending with specified substring',
     'selector': '#attr-ends [class\$=apple ]',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 3,
     'testType': testQsaAdditional
   },
@@ -717,7 +717,7 @@ var validSelectors = [
   {
     'name': ':root pseudo-class selector, not matching document root element',
     'selector': ':root',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'exclude': ['document'],
     'level': 3,
     'testType': testQsaAdditional
@@ -946,7 +946,7 @@ var validSelectors = [
         ":first-child pseudo-class selector, doesn't match non-first-child elements",
     'selector':
         '.pseudo-first-child-div2:first-child, .pseudo-first-child-div3:first-child',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -977,7 +977,7 @@ var validSelectors = [
         ":last-child pseudo-class selector, doesn't match non-last-child elements",
     'selector':
         '.pseudo-last-child-div1:last-child, .pseudo-last-child-div2:first-child',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 3,
     'testType': testQsaAdditional
   },
@@ -1007,7 +1007,7 @@ var validSelectors = [
     'name':
         ':pseudo-only-child pseudo-class selector, matching only-child em elements',
     'selector': '#pseudo-only em:only-child',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 3,
     'testType': testQsaAdditional
   },
@@ -1070,7 +1070,7 @@ var validSelectors = [
     'name':
         ':link and :visited pseudo-class selectors, not matching link elements with href attributes',
     'selector': '#head :link, #head :visited',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'exclude': ['document'],
     'level': 1,
     'testType': testQsaBaseline
@@ -1079,7 +1079,7 @@ var validSelectors = [
     'name':
         ':link and :visited pseudo-class selectors, chained, mutually exclusive pseudo-classes match nothing',
     'selector': ':link:visited',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'exclude': ['document'],
     'level': 1,
     'testType': testQsaBaseline
@@ -1090,7 +1090,7 @@ var validSelectors = [
     'name':
         ':target pseudo-class selector, matching the element referenced by the URL fragment identifier',
     'selector': ':target',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'exclude': ['document', 'element'],
     'level': 3,
     'testType': testQsaAdditional
@@ -1118,7 +1118,7 @@ var validSelectors = [
     'name':
         ':lang pseudo-class selector, not matching element with no inherited language',
     'selector': '#pseudo-lang-div1:lang(en)',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'exclude': ['document', 'element'],
     'level': 2,
     'testType': testQsaBaseline
@@ -1142,7 +1142,7 @@ var validSelectors = [
   {
     'name': ':lang pseudo-class selector, not matching incorrect language',
     'selector': '#pseudo-lang-div4:lang(es-AR)',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -1224,14 +1224,14 @@ var validSelectors = [
   {
     'name': ':not pseudo-class selector, matching nothing',
     'selector': ':not(*)',
-    'expect': [] /* no matches */,
+    'expect': <String>[] /* no matches */,
     'level': 3,
     'testType': testQsaAdditional
   },
   {
     'name': ':not pseudo-class selector, matching nothing',
     'selector': ':not(*|*)',
-    'expect': [] /* no matches */,
+    'expect': <String>[] /* no matches */,
     'level': 3,
     'testType': testQsaAdditional
   },
@@ -1242,7 +1242,7 @@ var validSelectors = [
     'name':
         ':first-line pseudo-element (one-colon syntax) selector, not matching any elements',
     'selector': '#pseudo-element:first-line',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -1250,7 +1250,7 @@ var validSelectors = [
     'name':
         '::first-line pseudo-element (two-colon syntax) selector, not matching any elements',
     'selector': '#pseudo-element::first-line',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 3,
     'testType': testQsaAdditional
   },
@@ -1260,7 +1260,7 @@ var validSelectors = [
     'name':
         ':first-letter pseudo-element (one-colon syntax) selector, not matching any elements',
     'selector': '#pseudo-element:first-letter',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -1268,7 +1268,7 @@ var validSelectors = [
     'name':
         '::first-letter pseudo-element (two-colon syntax) selector, not matching any elements',
     'selector': '#pseudo-element::first-letter',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 3,
     'testType': testQsaAdditional
   },
@@ -1278,7 +1278,7 @@ var validSelectors = [
     'name':
         ':before pseudo-element (one-colon syntax) selector, not matching any elements',
     'selector': '#pseudo-element:before',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -1286,7 +1286,7 @@ var validSelectors = [
     'name':
         '::before pseudo-element (two-colon syntax) selector, not matching any elements',
     'selector': '#pseudo-element::before',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 3,
     'testType': testQsaAdditional
   },
@@ -1296,7 +1296,7 @@ var validSelectors = [
     'name':
         ':after pseudo-element (one-colon syntax) selector, not matching any elements',
     'selector': '#pseudo-element:after',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -1304,7 +1304,7 @@ var validSelectors = [
     'name':
         '::after pseudo-element (two-colon syntax) selector, not matching any elements',
     'selector': '#pseudo-element::after',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 3,
     'testType': testQsaAdditional
   },
@@ -1413,14 +1413,14 @@ var validSelectors = [
   {
     'name': 'ID selector, not matching non-existent descendant',
     'selector': '#id #none',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 1,
     'testType': testQsaBaseline
   },
   {
     'name': 'ID selector, not matching non-existent ancestor',
     'selector': '#none #id-div1',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 1,
     'testType': testQsaBaseline
   },
@@ -1565,7 +1565,7 @@ var validSelectors = [
     'name':
         'Descendant combinator, not matching element with id that is not a descendant of an element with id',
     'selector': '#descendant-div1 #descendant-div4',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 1,
     'testType': testQsaBaseline
   },
@@ -1622,7 +1622,7 @@ var validSelectors = [
     'name':
         'Child combinator, not matching element with id that is not a child of an element with id',
     'selector': '#child>#child-div3',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -1630,7 +1630,7 @@ var validSelectors = [
     'name':
         'Child combinator, not matching element with id that is not a child of an element with class',
     'selector': '#child-div1>.child-div3',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -1638,7 +1638,7 @@ var validSelectors = [
     'name':
         'Child combinator, not matching element with class that is not a child of an element with class',
     'selector': '.child-div1>.child-div3',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -1724,7 +1724,7 @@ var validSelectors = [
     'name':
         'Adjacent sibling combinator, not matching element with id that is not an adjacent sibling of an element with id',
     'selector': '#adjacent-div2+#adjacent-p2, #adjacent-div2+#adjacent-div1',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 2,
     'testType': testQsaBaseline
   },
@@ -1802,7 +1802,7 @@ var validSelectors = [
     'name':
         'General sibling combinator, not matching element with id that is not a sibling after a p element',
     'selector': '#sibling>p~div',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 3,
     'testType': testQsaAdditional
   },
@@ -1810,7 +1810,7 @@ var validSelectors = [
     'name':
         'General sibling combinator, not matching element with id that is not a sibling after an element with id',
     'selector': '#sibling-div2~#sibling-div3, #sibling-div2~#sibling-div1',
-    'expect': [] /*no matches*/,
+    'expect': <String>[] /*no matches*/,
     'level': 3,
     'testType': testQsaAdditional
   },

--- a/test/support.dart
+++ b/test/support.dart
@@ -15,7 +15,7 @@ typedef TreeBuilderFactory = TreeBuilder Function(bool namespaceHTMLElements);
 Map<String, TreeBuilderFactory>? _treeTypes;
 Map<String, TreeBuilderFactory>? get treeTypes {
   // TODO(jmesserly): add DOM here once it's implemented
-  _treeTypes ??= {'simpletree': (useNs) => TreeBuilder(useNs)};
+  _treeTypes ??= {'simpletree': TreeBuilder.new};
   return _treeTypes;
 }
 
@@ -144,7 +144,7 @@ class TestSerializer extends TreeVisitor {
   }
 
   @override
-  void visitDocument(node) => _visitDocumentOrFragment(node);
+  void visitDocument(Document node) => _visitDocumentOrFragment(node);
 
   void _visitDocumentOrFragment(Node node) {
     indent += 1;


### PR DESCRIPTION
- finish the work to remove dynamic calls (fix https://github.com/dart-lang/html/issues/173)
- reduce use of dynamic generally; add additional types at the API boundary
- update to `package:lints` 2.0
- rev to `0.15.2-dev` (there are some other things I'd like to land before a publish)