### PR TITLE
widen the dependency on 'package:csslib'

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [2.17.0, dev]
+        sdk: [2.19.0, stable, dev]
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.15.4
 
 - Widen the dependency on `package:csslib`.
+- Require Dart `2.19`.
 
 ## 0.15.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.15.4
+
+- Widen the dependency on `package:csslib`.
+
 ## 0.15.3
 
 - Added package topics to the pubspec file.

--- a/lib/src/css_class_set.dart
+++ b/lib/src/css_class_set.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // TODO(jmesserly): everything in this file is copied straight from "dart:html".
-library html.dom.src;
 
 import 'dart:collection';
 

--- a/lib/src/tokenizer.dart
+++ b/lib/src/tokenizer.dart
@@ -1,5 +1,3 @@
-library tokenizer;
-
 import 'dart:collection';
 
 import 'package:html/parser.dart' show HtmlParser;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: html
-version: 0.15.3
+version: 0.15.4
 description: APIs for parsing and manipulating HTML content outside the browser.
 repository: https://github.com/dart-lang/html
 
@@ -8,13 +8,13 @@ topics:
   - web
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  csslib: ^0.17.0
+  csslib: '>=0.17.0 <2.0.0'
   source_span: ^1.8.0
 
 dev_dependencies:
-  dart_flutter_team_lints: ^0.1.0
+  dart_flutter_team_lints: ^1.0.0
   path: ^1.8.0
   test: ^1.16.0

--- a/test/query_selector_test.dart
+++ b/test/query_selector_test.dart
@@ -1,5 +1,3 @@
-library query_selector_test;
-
 import 'package:html/dom.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
- Widen the dependency on `package:csslib`.
- prep for publishing

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
