### PR TITLE
Don't throw on not-matching elements in visitPseudoClassSelector

### DIFF
--- a/lib/src/query_selector.dart
+++ b/lib/src/query_selector.dart
@@ -176,10 +176,7 @@ class SelectorEvaluator extends Visitor {
         return false;
     }
 
-    // :before, :after, :first-letter/line can't match DOM elements.
-    if (_isLegacyPsuedoClass(node.name)) return false;
-
-    throw _unimplemented(node);
+    return false;
   }
 
   @override

--- a/lib/src/query_selector.dart
+++ b/lib/src/query_selector.dart
@@ -111,8 +111,6 @@ class SelectorEvaluator extends Visitor {
           break;
         case TokenKind.COMBINATOR_NONE:
           break;
-        default:
-          throw _unsupported(node);
       }
 
       if (_element == null) {
@@ -124,13 +122,6 @@ class SelectorEvaluator extends Visitor {
     _element = old;
     return result;
   }
-
-  UnimplementedError _unimplemented(SimpleSelector selector) =>
-      UnimplementedError("'$selector' selector of type "
-          '${selector.runtimeType} is not implemented');
-
-  FormatException _unsupported(TreeNode selector) =>
-      FormatException("'$selector' is not a valid selector");
 
   @override
   bool visitPseudoClassSelector(PseudoClassSelector node) {
@@ -180,28 +171,10 @@ class SelectorEvaluator extends Visitor {
   }
 
   @override
-  bool visitPseudoElementSelector(PseudoElementSelector node) {
-    // :before, :after, :first-letter/line can't match DOM elements.
-    if (_isLegacyPsuedoClass(node.name)) return false;
-
-    throw _unimplemented(node);
-  }
-
-  static bool _isLegacyPsuedoClass(String name) {
-    switch (name) {
-      case 'before':
-      case 'after':
-      case 'first-line':
-      case 'first-letter':
-        return true;
-      default:
-        return false;
-    }
-  }
+  bool visitPseudoElementSelector(PseudoElementSelector node) => false;
 
   @override
-  bool visitPseudoElementFunctionSelector(PseudoElementFunctionSelector node) =>
-      throw _unimplemented(node);
+  bool visitPseudoElementFunctionSelector(PseudoElementFunctionSelector node) => false;
 
   @override
   bool visitPseudoClassFunctionSelector(PseudoClassFunctionSelector node) {
@@ -230,7 +203,7 @@ class SelectorEvaluator extends Visitor {
         // TODO(jmesserly): implement wildcards in level 4
         return lang != null && lang.startsWith(toMatch);
     }
-    throw _unimplemented(node);
+    return false;
   }
 
   static String? _getInheritedLanguage(Node? node) {
@@ -251,7 +224,7 @@ class SelectorEvaluator extends Visitor {
 
     if (node.namespace == '') return _element!.namespaceUri == null;
 
-    throw _unimplemented(node);
+    return false;
   }
 
   @override
@@ -296,7 +269,7 @@ class SelectorEvaluator extends Visitor {
       case TokenKind.SUBSTRING_MATCH:
         return value.contains(select);
       default:
-        throw _unsupported(node);
+        return false;
     }
   }
 }


### PR DESCRIPTION
This is for dart-lang/tools#1079. I personally do not wish to have an exception thrown because of a simple typo in an html selector, that seems wildly excessive. The selector wouldn't be able to be used anyway.
While silently ignoring errors is not great, in this case it is the better option for me in practice.
This PR is here moreso to raise awareness on the issue then anything else ; ideas on how to handle this by giving more leverage over the matching process to devs are welcome.